### PR TITLE
Fixed version parsing

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -51,7 +51,7 @@ int main ()
 		return 0;
 	}
 	return 1;
-}], [ac_cv_v8_version=`cat ./conftestval`], [ac_cv_v8_version=NONE], [ac_cv_v8_version=NONE])
+}], [ac_cv_v8_version=`cat ./conftestval|awk '{print $1}'`], [ac_cv_v8_version=NONE], [ac_cv_v8_version=NONE])
 AC_LANG_RESTORE
 LIBS=$old_LIBS
 LDFLAGS=$old_LDFLAGS


### PR DESCRIPTION
Extracting just the first part of the version number, in some cases where not only a number is present in the version number. Fixes build on Mac OS X Lion.
