### PR TITLE
Memory leak in php_v8js_v8_get_properties

### DIFF
--- a/v8js.cc
+++ b/v8js.cc
@@ -231,10 +231,15 @@ static HashTable *php_v8js_v8_get_properties(zval *object TSRMLS_DC) /* {{{ */
 	v8::Locker locker(obj->isolate);
 	v8::Isolate::Scope isolate_scope(obj->isolate);
 	v8::HandleScope local_scope(obj->isolate);
+	v8::Persistent<v8::Context> temp_context = v8::Context::New();
+	v8::Context::Scope temp_scope(temp_context);
 
 	if (php_v8js_v8_get_properties_hash(obj->v8obj, retval, obj->flags, obj->isolate TSRMLS_CC) == SUCCESS) {
+		temp_context.Dispose();
 		return retval;
 	}
+
+	temp_context.Dispose();
 	return NULL;
 }
 /* }}} */


### PR DESCRIPTION
Hi there,

in `php_v8js_v8_get_properties` `v8::Context::New` is called, which allocates a new _permanent_ context, and the result is assigned to `temp_context` variable.  However the variable is neither used anywhere nor is it disposed at the end.  Hence the permanent context is leaked.

Small example to reproduce:

```
ini_set("v8js.flags", "--trace_gc");
$v8 = new V8Js();

class Failer {
    function call($a) {
        print_r($a, true);
    }   
}

$v8->failer = new Failer();
$v8->executeString('
    for(;;) {
        PHP.failer.call({ foo: 23 });
    }
');
```

cheers,
  stesie
