### PR TITLE
Use v8::Isolate version of v8::Context::New

### DIFF
--- a/v8js.cc
+++ b/v8js.cc
@@ -231,15 +231,13 @@ static HashTable *php_v8js_v8_get_properties(zval *object TSRMLS_DC) /* {{{ */
 	v8::Locker locker(obj->isolate);
 	v8::Isolate::Scope isolate_scope(obj->isolate);
 	v8::HandleScope local_scope(obj->isolate);
-	v8::Persistent<v8::Context> temp_context = v8::Context::New();
+	v8::Local<v8::Context> temp_context = v8::Context::New(obj->isolate);
 	v8::Context::Scope temp_scope(temp_context);
 
 	if (php_v8js_v8_get_properties_hash(obj->v8obj, retval, obj->flags, obj->isolate TSRMLS_CC) == SUCCESS) {
-		temp_context.Dispose();
 		return retval;
 	}
 
-	temp_context.Dispose();
 	return NULL;
 }
 /* }}} */
@@ -596,7 +594,7 @@ static PHP_METHOD(V8Js, __construct)
 	php_v8js_register_methods(c->global_template->InstanceTemplate(), c);
 
 	/* Create context */
-	c->context = v8::Context::New(&extension_conf, c->global_template->InstanceTemplate());
+	c->context = v8::Persistent<v8::Context>::New(v8::Context::New(c->isolate, &extension_conf, c->global_template->InstanceTemplate()));
 	c->context->SetAlignedPointerInEmbedderData(1, c);
 
 	if (exts) {

--- a/v8js_methods.cc
+++ b/v8js_methods.cc
@@ -272,7 +272,7 @@ V8JS_METHOD(require)
 	global->Set(v8::String::New("module"), module);
 
 	// Each module gets its own context so different modules do not affect each other
-	v8::Persistent<v8::Context> context = v8::Context::New(NULL, global);
+	v8::Persistent<v8::Context> context = v8::Persistent<v8::Context>::New(v8::Context::New(c->isolate, NULL, global));
 
 	// Catch JS exceptions
 	v8::TryCatch try_catch;


### PR DESCRIPTION
The v8 library doesn't define the `v8::Context::New` function any longer, unless the library is compiled with `V8_USE_UNSAFE_HANDLES` ... which it isn't anymore by default.

This patch switches to the `v8::Context::New` methods with `v8::Isolate` passing.

In combination with the define from issue #19 v8js compiles with version 3.19.18 and passes the test suite.

cheers,
  stesie

NB: I wonder whether to just define `V8_USE_UNSAFE_HANDLES` in `php_v8js_macros.h` for the time being and hold on ...
