### PR TITLE
Add test for regression pointed out in pull request #14

### DIFF
--- a/tests/context_temp_creation.phpt
+++ b/tests/context_temp_creation.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Test V8::executeString() : correct temp context construction
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$v8 = new V8Js();
+
+class Failer {
+    protected $_b = null;
+
+    function call($a) {
+        $this->_b = $a;
+    } 
+
+    function test() {
+        print_r($this->_b);
+    }
+}
+
+$v8->failer = new Failer();
+$v8->executeString('PHP.failer.call({ foo: 23 });');
+$v8->failer->test();
+?>
+===EOF===
+--EXPECT--
+V8Object Object
+(
+    [foo] => 23
+)
+===EOF===


### PR DESCRIPTION
Hi again,

I've added a small test on what I almost broke accidentally with my earlier pull request #14

The temporary context there is certainly needed and this test simply fails if it is not provided.

I decided to add it since the pull request before touches this function yet another time :-)

cheers,
  stesie
