### PR TITLE
Replace deprecated calls to V8 API by newer equivalents

### DIFF
--- a/php_v8js_macros.h
+++ b/php_v8js_macros.h
@@ -50,7 +50,7 @@ extern "C" {
 #define V8JS_BOOL(v)		v8::Boolean::New(v)
 #define V8JS_NULL			v8::Null()
 #define V8JS_MN(name)		v8js_method_##name
-#define V8JS_METHOD(name)	v8::Handle<v8::Value> V8JS_MN(name)(const v8::Arguments& args)
+#define V8JS_METHOD(name)	void V8JS_MN(name)(const v8::FunctionCallbackInfo<v8::Value>& info)
 #define V8JS_THROW(type, message, message_len)	v8::ThrowException(v8::Exception::type(V8JS_STRL(message, message_len)))
 #define V8JS_GLOBAL			v8::Context::GetCurrent()->Global()
 

--- a/v8js.cc
+++ b/v8js.cc
@@ -389,7 +389,7 @@ void php_v8js_create_v8(zval *res, v8::Handle<v8::Value> value, int flags, v8::I
 
 	c = (php_v8js_object *) zend_object_store_get_object(res TSRMLS_CC);
 
-	c->v8obj = v8::Persistent<v8::Value>::New(value);
+	c->v8obj = v8::Persistent<v8::Value>::New(isolate, value);
 	c->flags = flags;
 	c->isolate = isolate;
 }
@@ -587,14 +587,14 @@ static PHP_METHOD(V8Js, __construct)
 	/* Create global template for global object */
 	// Now we are using multiple isolates this needs to be created for every context
 
-	c->global_template = v8::Persistent<v8::FunctionTemplate>::New(v8::FunctionTemplate::New());
+	c->global_template = v8::Persistent<v8::FunctionTemplate>::New(c->isolate, v8::FunctionTemplate::New());
 	c->global_template->SetClassName(V8JS_SYM("V8Js"));
 
 	/* Register builtin methods */
 	php_v8js_register_methods(c->global_template->InstanceTemplate(), c);
 
 	/* Create context */
-	c->context = v8::Persistent<v8::Context>::New(v8::Context::New(c->isolate, &extension_conf, c->global_template->InstanceTemplate()));
+	c->context = v8::Persistent<v8::Context>::New(c->isolate, v8::Context::New(c->isolate, &extension_conf, c->global_template->InstanceTemplate()));
 	c->context->SetAlignedPointerInEmbedderData(1, c);
 
 	if (exts) {
@@ -632,7 +632,7 @@ static PHP_METHOD(V8Js, __construct)
 	}
 
 	/* Set name for the PHP JS object */
-	c->object_name = v8::Persistent<v8::String>::New((object_name_len) ? V8JS_SYML(object_name, object_name_len) : V8JS_SYM("PHP"));
+	c->object_name = v8::Persistent<v8::String>::New(c->isolate, (object_name_len) ? V8JS_SYML(object_name, object_name_len) : V8JS_SYM("PHP"));
 
 	/* Add the PHP object into global object */
 	V8JS_GLOBAL->Set(c->object_name, php_obj_t->InstanceTemplate()->NewInstance(), v8::ReadOnly);

--- a/v8js_methods.cc
+++ b/v8js_methods.cc
@@ -36,15 +36,13 @@ void php_v8js_commonjs_normalise_identifier(char *base, char *identifier, char *
 V8JS_METHOD(exit) /* {{{ */
 {
 	v8::V8::TerminateExecution();
-	return v8::Undefined();
 }
 /* }}} */
 
 /* global.sleep - sleep for passed seconds */
 V8JS_METHOD(sleep) /* {{{ */
 {
-	php_sleep(args[0]->Int32Value());
-	return v8::Undefined();
+	php_sleep(info[0]->Int32Value());
 }
 /* }}} */
 
@@ -54,12 +52,12 @@ V8JS_METHOD(print) /* {{{ */
 	int ret = 0;
 	TSRMLS_FETCH();
 
-	for (int i = 0; i < args.Length(); i++) {
-		v8::String::Utf8Value str(args[i]);
+	for (int i = 0; i < info.Length(); i++) {
+		v8::String::Utf8Value str(info[i]);
 		const char *cstr = ToCString(str);
 		ret = PHPWRITE(cstr, strlen(cstr));
 	}
-	return V8JS_INT(ret);
+	info.GetReturnValue().Set(V8JS_INT(ret));
 }
 /* }}} */
 
@@ -161,26 +159,27 @@ V8JS_METHOD(var_dump) /* {{{ */
 	int i;
 	TSRMLS_FETCH();
 
-	for (int i = 0; i < args.Length(); i++) {
-		_php_v8js_dumper(args[i], 1 TSRMLS_CC);
+	for (int i = 0; i < info.Length(); i++) {
+		_php_v8js_dumper(info[i], 1 TSRMLS_CC);
 	}
 
-	return V8JS_NULL;
+	info.GetReturnValue().Set(V8JS_NULL);
 }
 /* }}} */
 
 V8JS_METHOD(require)
 {
 	// Get the extension context
-	v8::Handle<v8::External> data = v8::Handle<v8::External>::Cast(args.Data());
+	v8::Handle<v8::External> data = v8::Handle<v8::External>::Cast(info.Data());
 	php_v8js_ctx *c = static_cast<php_v8js_ctx*>(data->Value());
 
 	// Check that we have a module loader
 	if (c->module_loader == NULL) {
-		return v8::ThrowException(v8::String::New("No module loader"));
+		info.GetReturnValue().Set(v8::ThrowException(v8::String::New("No module loader")));
+		return;
 	}
 
-	v8::String::Utf8Value module_id_v8(args[0]);
+	v8::String::Utf8Value module_id_v8(info[0]);
 
 	// Make sure to duplicate the module name string so it doesn't get freed by the V8 garbage collector
 	char *module_id = estrdup(ToCString(module_id_v8));
@@ -207,7 +206,8 @@ V8JS_METHOD(require)
     	if (!strcmp(*it, normalised_module_id)) {
     		efree(normalised_path);
 
-    		return v8::ThrowException(v8::String::New("Module cyclic dependency"));
+		info.GetReturnValue().Set(v8::ThrowException(v8::String::New("Module cyclic dependency")));
+		return;
     	}
     }
 
@@ -215,7 +215,8 @@ V8JS_METHOD(require)
 	if (V8JSG(modules_loaded).count(normalised_module_id) > 0) {
 		efree(normalised_path);
 
-		return V8JSG(modules_loaded)[normalised_module_id];
+		info.GetReturnValue().Set(V8JSG(modules_loaded)[normalised_module_id]);
+		return;
 	}
 
 	// Callback to PHP to load the module code
@@ -230,7 +231,8 @@ V8JS_METHOD(require)
 	if (FAILURE == call_user_function(EG(function_table), NULL, c->module_loader, &module_code, 1, params TSRMLS_CC)) {
 		efree(normalised_path);
 
-		return v8::ThrowException(v8::String::New("Module loader callback failed"));
+		info.GetReturnValue().Set(v8::ThrowException(v8::String::New("Module loader callback failed")));
+		return;
 	}
 
 	// Check if an exception was thrown
@@ -239,7 +241,8 @@ V8JS_METHOD(require)
 
 		// Clear the PHP exception and throw it in V8 instead
 		zend_clear_exception(TSRMLS_CC);
-		return v8::ThrowException(v8::String::New("Module loader callback exception"));
+		info.GetReturnValue().Set(v8::ThrowException(v8::String::New("Module loader callback exception")));
+		return;
 	}
 
 	// Convert the return value to string
@@ -251,7 +254,8 @@ V8JS_METHOD(require)
 	if (!strlen(Z_STRVAL(module_code))) {
 		efree(normalised_path);
 
-		return v8::ThrowException(v8::String::New("Module loader callback did not return code"));
+		info.GetReturnValue().Set(v8::ThrowException(v8::String::New("Module loader callback did not return code")));
+		return;
 	}
 
 	// Create a template for the global object and set the built-in global functions
@@ -272,7 +276,7 @@ V8JS_METHOD(require)
 	global->Set(v8::String::New("module"), module);
 
 	// Each module gets its own context so different modules do not affect each other
-	v8::Persistent<v8::Context> context = v8::Persistent<v8::Context>::New(v8::Context::New(c->isolate, NULL, global));
+	v8::Persistent<v8::Context> context = v8::Persistent<v8::Context>::New(c->isolate, v8::Context::New(c->isolate, NULL, global));
 
 	// Catch JS exceptions
 	v8::TryCatch try_catch;
@@ -295,7 +299,8 @@ V8JS_METHOD(require)
 	// The script will be empty if there are compile errors
 	if (script.IsEmpty()) {
 		efree(normalised_path);
-		return v8::ThrowException(v8::String::New("Module script compile failed"));
+		info.GetReturnValue().Set(v8::ThrowException(v8::String::New("Module script compile failed")));
+		return;
 	}
 
 	// Add this module and path to the stack
@@ -314,13 +319,15 @@ V8JS_METHOD(require)
 
 	// Script possibly terminated, return immediately
 	if (!try_catch.CanContinue()) {
-		return v8::ThrowException(v8::String::New("Module script compile failed"));
+		info.GetReturnValue().Set(v8::ThrowException(v8::String::New("Module script compile failed")));
+		return;
 	}
 
 	// Handle runtime JS exceptions
 	if (try_catch.HasCaught()) {
 		// Rethrow the exception back to JS
-		return try_catch.ReThrow();
+		info.GetReturnValue().Set(try_catch.ReThrow());
+		return;
 	}
 
 	// Cache the module so it doesn't need to be compiled and run again
@@ -333,7 +340,7 @@ V8JS_METHOD(require)
 		V8JSG(modules_loaded)[normalised_module_id] = handle_scope.Close(exports);
 	}
 
-	return V8JSG(modules_loaded)[normalised_module_id];
+	info.GetReturnValue().Set(V8JSG(modules_loaded)[normalised_module_id]);
 }
 
 void php_v8js_register_methods(v8::Handle<v8::ObjectTemplate> global, php_v8js_ctx *c) /* {{{ */

--- a/v8js_variables.cc
+++ b/v8js_variables.cc
@@ -38,7 +38,7 @@ struct php_v8js_accessor_ctx
     v8::Isolate *isolate;
 };
 
-static v8::Handle<v8::Value> php_v8js_fetch_php_variable(v8::Local<v8::String> name, const v8::AccessorInfo &info) /* {{{ */
+static void php_v8js_fetch_php_variable(v8::Local<v8::String> name, const v8::PropertyCallbackInfo<v8::Value>& info) /* {{{ */
 {
     v8::Handle<v8::External> data = v8::Handle<v8::External>::Cast(info.Data());
     php_v8js_accessor_ctx *ctx = static_cast<php_v8js_accessor_ctx *>(data->Value());
@@ -49,10 +49,9 @@ static v8::Handle<v8::Value> php_v8js_fetch_php_variable(v8::Local<v8::String> n
 	zend_is_auto_global(ctx->variable_name_string, ctx->variable_name_string_len TSRMLS_CC);
 
 	if (zend_hash_find(&EG(symbol_table), ctx->variable_name_string, ctx->variable_name_string_len + 1, (void **) &variable) == SUCCESS) {
-		return zval_to_v8js(*variable, ctx->isolate TSRMLS_CC);
+		info.GetReturnValue().Set(zval_to_v8js(*variable, ctx->isolate TSRMLS_CC));
+		return;
 	}
-
-	return v8::Undefined();
 }
 /* }}} */
 


### PR DESCRIPTION
Hi again,

I've replaced calls to deprecated V8 API functions with newer equivalents.  This is mainly passing around some more v8::Isolate instances and adopting new callback function scheme.

This work is based on my earlier pull request #21.  I've split this into two pull requests to allow for quicker merging of the former, since it is far more critical as it already prevents this module from building.

cheers,
  stesie
