### PR TITLE
V8Js fails if multiple instances are created using object-passing

### DIFF
--- a/tests/multi-object.phpt
+++ b/tests/multi-object.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Test V8::executeString() : Use multiple V8js instances with objects
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+class TestClass {
+	protected $_instNo;
+
+	public function __construct($num) {
+		$this->_instNo = $num;
+	}
+
+	public function sayHello() {
+		echo 'Hello World!  This is instance '.$this->_instNo."\n";
+	}
+}
+
+$instances = array();
+for($i = 0; $i < 5; $i ++) {
+	$v8 = new V8Js();
+	$v8->test = new TestClass($i);
+	$instances[] = $v8;
+}
+
+$JS = <<< EOT
+php.test.sayHello();
+EOT;
+
+foreach($instances as $v8) {
+	$v8->executeString($JS, 'basic.js');
+}
+
+?>
+===EOF===
+--EXPECT--
+Hello World!  This is instance 0
+Hello World!  This is instance 1
+Hello World!  This is instance 2
+Hello World!  This is instance 3
+Hello World!  This is instance 4
+===EOF===

--- a/tests/multi.phpt
+++ b/tests/multi.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Test V8::executeString() : Use multiple V8js instances
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$instances = array();
+for($i = 0; $i < 5; $i ++) {
+	$v8 = new V8Js();
+	$v8->executeString('var instNo = '.$i);
+	$instances[] = $v8;
+}
+
+$JS = <<< EOT
+len = print('Hello' + ' ' + 'World!  This is instance ' + instNo + "\\n");
+len;
+EOT;
+
+foreach($instances as $v8) {
+	$v8->executeString($JS, 'basic.js');
+}
+
+?>
+===EOF===
+--EXPECT--
+Hello World!  This is instance 0
+Hello World!  This is instance 1
+Hello World!  This is instance 2
+Hello World!  This is instance 3
+Hello World!  This is instance 4
+===EOF===


### PR DESCRIPTION
hi there,

I recently noticed that V8Js causes segmentation faults if it is instanciated multiple times and objects are passed from PHP to JavaScript.  If no objects are passed it doesn't crash.

For the moment here's just a failing test, I'll investigate further the next days ... I assume it's related to my memory leak optimizations some months ago ... 

cheers
  stesie
