### PR TITLE
The json extension is not needed for PHP 5.4.

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -1,4 +1,7 @@
+# add json extension, if needed (ie, for PHP >= 5.5)
+ifneq (,$(realpath $(EXTENSION_DIR)/json.so))
 PHP_TEST_SHARED_EXTENSIONS+=-d extension=$(EXTENSION_DIR)/json.so
+endif
 
 testv8: all
 	$(PHP_EXECUTABLE) -n -d extension_dir=./modules -d extension=v8js.so test.php


### PR DESCRIPTION
Fixes issue raised by @stesie in https://github.com/preillyme/v8js/commit/20d038fae53c9baae37e954bb786325b045a4c5f#commitcomment-4236851
