### PR TITLE
Use v8::Isolate as part of the key to the template cache

### DIFF
--- a/tests/multi-object.phpt
+++ b/tests/multi-object.phpt
@@ -25,7 +25,7 @@ for($i = 0; $i < 5; $i ++) {
 }
 
 $JS = <<< EOT
-php.test.sayHello();
+PHP.test.sayHello();
 EOT;
 
 foreach($instances as $v8) {


### PR DESCRIPTION
This fixes #34.

The v8 function templates used to pass objects from PHP to JavaScript world must not be shared between isolates.  Doing so anyways leads to segmentation faults as shown with multi-objects.phpt test submitted with issue #31

This patch adds the isolate pointer as another part of the cache key to omit reuse accross isolate bounds.

cheers
  stesie
