### PR TITLE
Fix php_v8js_hash_to_jsobj for v8 functions

### DIFF
--- a/php_v8js_macros.h
+++ b/php_v8js_macros.h
@@ -129,6 +129,16 @@ struct php_v8js_timer_ctx
   php_v8js_ctx *v8js_ctx;
 };
 
+/* {{{ Object container */
+struct php_v8js_object {
+	zend_object std;
+	v8::Persistent<v8::Value> v8obj;
+	int flags;
+	v8::Isolate *isolate;
+};
+/* }}} */
+
+
 /* Module globals */
 ZEND_BEGIN_MODULE_GLOBALS(v8js)
   int v8_initialized;

--- a/tests/function_passback.phpt
+++ b/tests/function_passback.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test V8::executeString() : Call passed-back function
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$v8 = new V8Js();
+
+$JS = <<< EOT
+(function(exports) {
+  // begin module code
+  exports.hello = function() { return 'hello'; };
+  // end module code
+  return exports;
+})({})
+EOT;
+
+$exports = $v8->executeString($JS, 'basic.js');
+$v8->func = get_object_vars( $exports )['hello'];
+
+echo $v8->executeString('PHP.func();')."\n";
+
+?>
+===EOF===
+--EXPECT--
+hello
+===EOF===

--- a/v8js.cc
+++ b/v8js.cc
@@ -101,15 +101,6 @@ struct php_v8js_jsext {
 };
 /* }}} */
 
-/* {{{ Object container */
-struct php_v8js_object {
-	zend_object std;
-	v8::Persistent<v8::Value> v8obj;
-	int flags;
-	v8::Isolate *isolate;
-};
-/* }}} */
-
 #ifdef COMPILE_DL_V8JS
 ZEND_GET_MODULE(v8js)
 #endif

--- a/v8js_convert.cc
+++ b/v8js_convert.cc
@@ -371,7 +371,10 @@ static v8::Handle<v8::Value> php_v8js_hash_to_jsobj(zval *value, v8::Isolate *is
 	}
 
 	/* Object methods */
-	if (ce) {
+	if (ce == php_ce_v8_function) {
+		php_v8js_object *c = (php_v8js_object *) zend_object_store_get_object(value TSRMLS_CC);
+		return c->v8obj;
+	} else if (ce) {
 		v8::Handle<v8::FunctionTemplate> new_tpl;
 		bool cached_tpl = true;
 		static TemplateCache tpl_map;


### PR DESCRIPTION
Currently if a function is returned from JavaScript to PHP context it's converted to a PHP object of V8Function class (ce=php_ce_v8_function).  If this function is passed back to JavaScript normal "object wrapping" takes place which results in JS context seeing an object of type "V8Function"

This patch makes php_v8js_hash_to_jsobj recognize the special class and instead passes back a handle to the original function.

This addresses the second part of @cscott's issue #33
