### PR TITLE
Ensure all v8 libraries are copied in README; sanity check in config.m4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cd v8
 make dependencies
 make native library=shared -j8
 sudo mkdir -p /usr/lib /usr/include
-sudo cp out/native/lib.target/libv8.so /usr/lib/libv8.so
+sudo cp out/native/lib.target/lib*.so /usr/lib/
 sudo cp include/v8* /usr/include
 
 ```

--- a/config.m4
+++ b/config.m4
@@ -72,6 +72,8 @@ CPPFLAGS=$old_CPPFLAGS
     fi
     AC_DEFINE_UNQUOTED([PHP_V8_API_VERSION], $V8_API_VERSION, [ ])
     AC_DEFINE_UNQUOTED([PHP_V8_VERSION], "$ac_cv_v8_version", [ ])
+  else
+    AC_MSG_ERROR([could not determine libv8 version])
   fi
   
   PHP_NEW_EXTENSION(v8js, v8js.cc v8js_convert.cc v8js_methods.cc v8js_variables.cc v8js_commonjs.cc, $ext_shared, , "-std=c++11")


### PR DESCRIPTION
The latest versions of v8 build libicu as well.  If this isn't copied to
the lib directory, then the v8 version check fails (with a link error).
Ensure that this is caught at configuration time.
