### PR TITLE
Build status badge for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 V8Js
 ====
 
+[![Build Status](http://jenkins.brokenpipe.de/job/v8js/badge/icon)](http://jenkins.brokenpipe.de/job/v8js/)
+
 V8Js is a PHP extension for Google's V8 Javascript engine.
 
 The extension allows you to execute Javascript code in a secure sandbox from PHP. The executed code can be restricted using a time limit and/or memory limit. This provides the possibility to execute untrusted code with confidence.
@@ -15,6 +17,8 @@ Minimum requirements
 	V8 is written in C++ and is used in Google Chrome, the open source browser from Google.
 	V8 implements ECMAScript as specified in ECMA-262, 5th edition.
     This extension makes use of V8 isolates to ensure separation between multiple V8Js instances and already uses the new persistence API, hence the need for 3.21.12 or above.
+
+    For a detailed overview of which V8 version V8Js can be successfully build against, see the [Jenkins V8Js job list](http://jenkins.brokenpipe.de/view/v8js-with-v8-versions/).
 
 - PHP 5.3.3+
 


### PR DESCRIPTION
hey,

inspired by the somewhat boring work for issue #40 of manually testing buildability of V8Js against certain V8 versions I decided to configure a Jenkins instance to do the following
- continuous builds (latest versions) of V8 and V8Js
- builds of V8Js against each and every version of V8 we consider supported (currently any >= 3.21.12)

Both V8Js and V8 repositories are checked once per hour for new commits.  Besides the V8 repository is checked daily for new releases which are auto-installed and V8Js being built against.

Based on the continuous build a badge image is created and linked into the README page.

Besides this should help us notice if V8Js is once more broken by V8 API changes or we break buildability with older versions.

cheers
  stesie
