### PR TITLE
Make test PHP 5.3 compatible

### DIFF
--- a/tests/function_passback.phpt
+++ b/tests/function_passback.phpt
@@ -17,7 +17,8 @@ $JS = <<< EOT
 EOT;
 
 $exports = $v8->executeString($JS, 'basic.js');
-$v8->func = get_object_vars( $exports )['hello'];
+$vars = get_object_vars($exports);
+$v8->func = $vars['hello'];
 
 echo $v8->executeString('PHP.func();')."\n";
 


### PR DESCRIPTION
tests/function_passback.phpt fails on PHP 5.3 since it uses PHP 5.4 syntax.

Since we target PHP 5.3+ according to README I fixed the test accordingly
