### PR TITLE
Make JavaScript function wrappers typesafe.

### DIFF
--- a/tests/object_method_call.phpt
+++ b/tests/object_method_call.phpt
@@ -61,6 +61,14 @@ try {
 	var_dump($e);
 }
 
+// Type safety
+// this is illegal, but shouldn't crash!
+try {
+	$a->executeString("PHP.myobj.mytest.call({})", "test8.js");
+} catch (V8JsScriptException $e) {
+	echo "exception: ", $e->getMessage(), "\n";
+}
+
 ?>
 ===EOF===
 --EXPECT--
@@ -143,4 +151,5 @@ array(3) {
     }
   }
 }
+exception: test8.js:1: TypeError: Illegal invocation
 ===EOF===


### PR DESCRIPTION
Use the v8::Signature parameter to FunctionTemplate::New to guarantee that the info->Holder() is of the proper type when `php_v8js_php_callback` is invoked.

Add test case demonstrating the segfault (which is now prevented).
