### PR TITLE
TSRM/ZTS fixes.

### DIFF
--- a/php_v8js_macros.h
+++ b/php_v8js_macros.h
@@ -164,6 +164,8 @@ ZEND_END_MODULE_GLOBALS(v8js)
 
 extern zend_v8js_globals v8js_globals;
 
+ZEND_EXTERN_MODULE_GLOBALS(v8js)
+
 #ifdef ZTS
 # define V8JSG(v) TSRMG(v8js_globals_id, zend_v8js_globals *, v)
 #else

--- a/v8js.cc
+++ b/v8js.cc
@@ -770,7 +770,7 @@ static PHP_METHOD(V8Js, __construct)
 	V8JS_GLOBAL->Set(object_name_js, php_obj, v8::ReadOnly);
 
 	/* Export public property values */
-	HashTable *properties = zend_std_get_properties(getThis());
+	HashTable *properties = zend_std_get_properties(getThis() TSRMLS_CC);
 	HashPosition pos;
 	zval **value;
 	ulong index;
@@ -1495,6 +1495,11 @@ static const zend_function_entry v8js_memory_limit_exception_methods[] = { /* {{
 static PHP_MINIT_FUNCTION(v8js)
 {
 	zend_class_entry ce;
+
+#ifdef ZTS
+	std::mutex mutex;
+	memcpy(&V8JSG(timer_mutex), &mutex, sizeof(V8JSG(timer_mutex)));
+#endif
 
 	/* V8Object Class */
 	INIT_CLASS_ENTRY(ce, "V8Object", NULL);

--- a/v8js_methods.cc
+++ b/v8js_methods.cc
@@ -163,6 +163,8 @@ V8JS_METHOD(var_dump) /* {{{ */
 
 V8JS_METHOD(require)
 {
+	TSRMLS_FETCH();
+
 	// Get the extension context
 	v8::Handle<v8::External> data = v8::Handle<v8::External>::Cast(info.Data());
 	php_v8js_ctx *c = static_cast<php_v8js_ctx*>(data->Value());
@@ -234,7 +236,7 @@ V8JS_METHOD(require)
 		efree(normalised_path);
 
 		// Clear the PHP exception and throw it in V8 instead
-		zend_clear_exception(TSRMLS_CC);
+		zend_clear_exception(TSRMLS_C);
 		info.GetReturnValue().Set(v8::ThrowException(v8::String::New("Module loader callback exception")));
 		return;
 	}


### PR DESCRIPTION
This fixes the build with ZTS enabled and mutex initialization which made all executeString calls just hang

The test suite passes only partially since some single ZVALs are leaked (which cause notices and hence differences from expected console output)
