### PR TITLE
Don't re-wrap PHP objects from V8 to V8Object

### DIFF
--- a/tests/object_method_call.phpt
+++ b/tests/object_method_call.phpt
@@ -113,15 +113,13 @@ Mon, 08 Sep 1975 09:00:00 +0000
 string(3) "foo"
 array(3) {
   [0]=>
-  object(V8Object)#4 (3) {
-    ["mytest"]=>
-    object(V8Function)#6 (0) {
-    }
-    ["mydatetest"]=>
-    object(V8Function)#7 (0) {
-    }
+  object(Testing)#2 (3) {
     ["foo"]=>
     string(8) "ORIGINAL"
+    ["my_private":"Testing":private]=>
+    string(3) "arf"
+    ["my_protected":protected]=>
+    string(4) "argh"
   }
   [1]=>
   array(3) {
@@ -139,15 +137,13 @@ array(3) {
     [1]=>
     string(3) "bar"
     [2]=>
-    object(V8Object)#5 (3) {
-      ["mytest"]=>
-      object(V8Function)#7 (0) {
-      }
-      ["mydatetest"]=>
-      object(V8Function)#6 (0) {
-      }
+    object(Testing)#2 (3) {
       ["foo"]=>
       string(8) "ORIGINAL"
+      ["my_private":"Testing":private]=>
+      string(3) "arf"
+      ["my_protected":protected]=>
+      string(4) "argh"
     }
   }
 }

--- a/tests/object_passback.phpt
+++ b/tests/object_passback.phpt
@@ -1,0 +1,74 @@
+--TEST--
+Test V8::executeString() : Object passing PHP > JS > PHP
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+class Bar {
+  function sayHello() {
+	echo "Hello\n";
+  }
+}
+
+class Foo {
+  function getBar() {
+	return new Bar();
+  }
+
+  function callMulti($list) {
+	foreach($list as $x) {
+	  echo get_class($x)."\n";  // V8Object vs. Bar
+	  $x->sayHello();
+	}
+  }
+
+  function callSingle($inst) {
+	echo get_class($inst)."\n";
+	$inst->sayHello();
+  }
+}
+
+$v8 = new V8Js();
+$v8->foo = new Foo();
+
+$JS = <<< EOF
+var obj = PHP.foo.getBar();
+PHP.foo.callMulti([obj]);
+PHP.foo.callMulti([obj]);
+PHP.foo.callSingle(obj);
+PHP.foo.callSingle(obj);
+
+obj = {};
+obj.sayHello = function() {
+	print("JavaScript Hello\\n");
+};
+
+PHP.foo.callMulti([obj]);
+PHP.foo.callMulti([obj]);
+PHP.foo.callSingle(obj);
+PHP.foo.callSingle(obj);
+EOF;
+
+$v8->executeString($JS);
+
+?>
+===EOF===
+--EXPECT--
+Bar
+Hello
+Bar
+Hello
+Bar
+Hello
+Bar
+Hello
+V8Object
+JavaScript Hello
+V8Object
+JavaScript Hello
+V8Object
+JavaScript Hello
+V8Object
+JavaScript Hello
+===EOF===

--- a/v8js_convert.cc
+++ b/v8js_convert.cc
@@ -110,14 +110,23 @@ static void php_v8js_call_php_func(zval *value, zend_class_entry *ce, zend_funct
 		fci.params = (zval ***) safe_emalloc(argc, sizeof(zval **), 0);
 		argv = (zval **) safe_emalloc(argc, sizeof(zval *), 0);
 		for (i = 0; i < argc; i++) {
-			MAKE_STD_ZVAL(argv[i]);
-			if (v8js_to_zval(info[i], argv[i], flags, isolate TSRMLS_CC) == FAILURE) {
-				fci.param_count++;
-				error_len = spprintf(&error, 0, "converting parameter #%d passed to %s() failed", i + 1, method_ptr->common.function_name);
-				return_value = V8JS_THROW(Error, error, error_len);
-				efree(error);
-				goto failure;
+			if(info[i]->IsObject()
+			   && !info[i]->IsFunction()
+			   && info[i]->ToObject()->InternalFieldCount() == 2) {
+				/* This is a PHP object, passed to JS and back. */
+				argv[i] = reinterpret_cast<zval *>(info[i]->ToObject()->GetAlignedPointerFromInternalField(0));
+				Z_ADDREF_P(argv[i]);
+			} else {
+				MAKE_STD_ZVAL(argv[i]);
+				if (v8js_to_zval(info[i], argv[i], flags, isolate TSRMLS_CC) == FAILURE) {
+					fci.param_count++;
+					error_len = spprintf(&error, 0, "converting parameter #%d passed to %s() failed", i + 1, method_ptr->common.function_name);
+					return_value = V8JS_THROW(Error, error, error_len);
+					efree(error);
+					goto failure;
+				}
 			}
+
 			fci.params[fci.param_count++] = &argv[i];
  		}
 	} else {


### PR DESCRIPTION
Currently if a PHP object is passed to V8 it gets wrapped to a V8 object, so far so good.

However if the JavaScript side passes this object back to another PHP function, then V8Js currently wrapps the V8 object again, so the called function sees a PHP object of type `V8Object`.  Instead I would expect the called function to see the original PHP object on which it is able to call methods on (which in turn are able to access private & protected properties).

See the newly added test case tests/object_passback.phpt for what I'm trying to do :-)

I had to adapt the object_method_call.phpt test case, since it currently `var_dump`s passed back objects and hence had `V8Object` written down ...
