### PR TITLE
Don't manually call destructors on v8js_globals.

### DIFF
--- a/v8js.cc
+++ b/v8js.cc
@@ -1729,9 +1729,11 @@ static PHP_GSHUTDOWN_FUNCTION(v8js)
 		v8js_globals->v8_flags = NULL;
 	}
 
+#if 0
 	v8js_globals->timer_stack.~stack();
 	v8js_globals->timer_mutex.~mutex();
 	v8js_globals->modules_loaded.~map();
+#endif
 }
 /* }}} */
 


### PR DESCRIPTION
v8js_globals is declared at the beginning of v8js.cc and hence
it's constructors and destructors are run automatically.

This fixes #66

I'm not yet 100% sure whether this doesn't re-introduce a (smallish) leak with ZTS, but it fixes the build at least.
