### PR TITLE
Simplify php_v8js_weak_object_callback.

### DIFF
--- a/v8js_convert.cc
+++ b/v8js_convert.cc
@@ -260,12 +260,7 @@ static void php_v8js_weak_object_callback(const v8::WeakCallbackData<v8::Object,
 	v8::Isolate *isolate = data.GetIsolate();
 	zval *value = data.GetParameter();
 	V8JS_TSRMLS_FETCH();
-	if (READY_TO_DESTROY(value)) {
-		zval_dtor(value);
-		FREE_ZVAL(value);
-	} else {
-		Z_DELREF_P(value);
-	}
+	zval_ptr_dtor(&value);
 
 	v8::V8::AdjustAmountOfExternalAllocatedMemory(-1024);
 }


### PR DESCRIPTION
This also fixes a leak in the `object_dom` testcase, where the DOM extension
returns an object with refcnt 1 but object_store refcnt 2, causing
READY_TO_DESTROY to return false.  Don't try to be fancy, just use the
standard PHP destructor.
