### PR TITLE
v8 compliation requires gclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Compile latest v8
 
 ```
 cd /tmp
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+export PATH=`pwd`/depot_tools:"$PATH"
 git clone https://github.com/v8/v8.git
 cd v8
 make dependencies


### PR DESCRIPTION
`make dependecies` task fails with `gclient not found` error.

gclient is a part of [depot-tools](http://dev.chromium.org/developers/how-tos/install-depot-tools)
