### PR TITLE
Fix pthread extension compatibility

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -3,6 +3,11 @@ ifneq (,$(realpath $(EXTENSION_DIR)/json.so))
 PHP_TEST_SHARED_EXTENSIONS+=-d extension=$(EXTENSION_DIR)/json.so
 endif
 
+# add pthreads extension, if available
+ifneq (,$(realpath $(EXTENSION_DIR)/pthreads.so))
+PHP_TEST_SHARED_EXTENSIONS+=-d extension=$(EXTENSION_DIR)/pthreads.so
+endif
+
 testv8: all
 	$(PHP_EXECUTABLE) -n -d extension_dir=./modules -d extension=v8js.so test.php
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Minimum requirements
 
 - PHP 5.3.3+
 
-  This embedded implementation of the V8 engine uses thread locking so it should work with ZTS enabled.
-  However, this has not been tested yet.
+  This embedded implementation of the V8 engine uses thread locking so it works with ZTS enabled.
 
 
 Compiling latest version

--- a/php_v8js_macros.h
+++ b/php_v8js_macros.h
@@ -113,10 +113,8 @@ void v8js_register_accessors(std::vector<v8js_accessor_ctx*> *accessor_list, v8:
 ZEND_BEGIN_MODULE_GLOBALS(v8js)
   // Thread-local cache whether V8 has been initialized so far
   int v8_initialized;
-  HashTable *extensions;
 
   /* Ini globals */
-  char *v8_flags; /* V8 command line flags */
   bool use_date; /* Generate JS Date objects instead of PHP DateTime */
   bool use_array_access; /* Convert ArrayAccess, Countable objects to array-like objects */
   bool compat_php_exceptions; /* Don't stop JS execution on PHP exception */
@@ -149,6 +147,8 @@ ZEND_EXTERN_MODULE_GLOBALS(v8js)
  *
  *  - whether V8 has been initialized at all
  *  - the V8 backend platform
+ *  - loaded extensions
+ *  - V8 "command line" flags
  *
  * In a ZTS-enabled environment access to all of these variables must happen
  * while holding a mutex lock.
@@ -158,6 +158,11 @@ struct _v8js_process_globals {
 	int v8_initialized;
 	std::mutex lock;
 #endif
+
+	HashTable *extensions;
+
+	/* V8 command line flags */
+	char *v8_flags;
 
 #if !defined(_WIN32) && PHP_V8_API_VERSION >= 3029036
 	v8::Platform *v8_platform;

--- a/tests/pthreads_001.phpt
+++ b/tests/pthreads_001.phpt
@@ -1,0 +1,65 @@
+--TEST--
+Test V8::executeString() : Pthreads test #1
+--SKIPIF--
+<?php
+require_once(dirname(__FILE__) . '/skipif.inc');
+if(!class_exists('Thread')) {
+    die('skip pthreads extension required');
+}
+?>
+--FILE--
+<?php
+
+class Workhorse extends Thread
+{
+    protected $val;
+
+    public function __construct($val)
+    {
+        $this->val = $val;
+    }
+
+    public function run()
+    {
+        $v8 = new V8Js();
+        $v8->val = $this->val;
+        $v8->sync_var_dump = function($value) {
+            $this->synchronized(function($thread) use ($value) {
+                    while(!$thread->readyToPrint) {
+                        $thread->wait();
+                    }
+                    var_dump($value);
+                    $thread->notify();
+                }, $this);
+        };
+
+        $v8->executeString('PHP.sync_var_dump(PHP.val);');
+    }
+}
+
+$foo = new Workhorse('foo');
+$bar = new Workhorse('bar');
+
+$foo->start();
+$bar->start();
+
+$bar->synchronized(function($thread) {
+    $thread->readyToPrint = true;
+    $thread->notify();
+    $thread->wait();
+}, $bar);
+
+$foo->synchronized(function($thread) {
+    $thread->readyToPrint = true;
+    $thread->notify();
+    $thread->wait();
+}, $foo);
+
+$foo->join();
+$bar->join();
+?>
+===EOF===
+--EXPECT--
+string(3) "bar"
+string(3) "foo"
+===EOF===

--- a/v8js.cc
+++ b/v8js.cc
@@ -35,15 +35,35 @@ struct _v8js_process_globals v8js_process_globals;
 
 static ZEND_INI_MH(v8js_OnUpdateV8Flags) /* {{{ */
 {
+	bool immutable = false;
+
+#ifdef ZTS
+	v8js_process_globals.lock.lock();
+
+	if(v8js_process_globals.v8_initialized) {
+		v8js_process_globals.lock.unlock();
+		immutable = true;
+	}
+
+	v8js_process_globals.lock.unlock();
+#else
+	immutable = V8JSG(v8_initialized);
+#endif
+
+	if(immutable) {
+		/* V8 already has been initialized -> cannot be changed anymore */
+		return FAILURE;
+	}
+
 	if (new_value) {
-		if (V8JSG(v8_flags)) {
-			free(V8JSG(v8_flags));
-			V8JSG(v8_flags) = NULL;
+		if (v8js_process_globals.v8_flags) {
+			free(v8js_process_globals.v8_flags);
+			v8js_process_globals.v8_flags = NULL;
 		}
 		if (!new_value[0]) {
 			return FAILURE;
 		}
-		V8JSG(v8_flags) = zend_strndup(new_value, new_value_length);
+		v8js_process_globals.v8_flags = zend_strndup(new_value, new_value_length);
 	}
 
 	return SUCCESS;
@@ -129,6 +149,17 @@ static PHP_MSHUTDOWN_FUNCTION(v8js)
 #endif
 	}
 
+	if (v8js_process_globals.v8_flags) {
+		free(v8js_process_globals.v8_flags);
+		v8js_process_globals.v8_flags = NULL;
+	}
+
+	if (v8js_process_globals.extensions) {
+		zend_hash_destroy(v8js_process_globals.extensions);
+		free(v8js_process_globals.extensions);
+		v8js_process_globals.extensions = NULL;
+	}
+
 	return SUCCESS;
 }
 /* }}} */
@@ -180,9 +211,7 @@ static PHP_GINIT_FUNCTION(v8js)
 	  run the destructors manually.
 	*/
 #ifdef ZTS
-	v8js_globals->extensions = NULL;
 	v8js_globals->v8_initialized = 0;
-	v8js_globals->v8_flags = NULL;
 
 	v8js_globals->timer_thread = NULL;
 	v8js_globals->timer_stop = false;
@@ -198,17 +227,6 @@ static PHP_GINIT_FUNCTION(v8js)
  */
 static PHP_GSHUTDOWN_FUNCTION(v8js)
 {
-	if (v8js_globals->extensions) {
-		zend_hash_destroy(v8js_globals->extensions);
-		free(v8js_globals->extensions);
-		v8js_globals->extensions = NULL;
-	}
-
-	if (v8js_globals->v8_flags) {
-		free(v8js_globals->v8_flags);
-		v8js_globals->v8_flags = NULL;
-	}
-
 #ifdef ZTS
 	v8js_globals->timer_stack.~deque();
 	v8js_globals->timer_mutex.~mutex();

--- a/v8js.cc
+++ b/v8js.cc
@@ -140,7 +140,15 @@ static PHP_MSHUTDOWN_FUNCTION(v8js)
 {
 	UNREGISTER_INI_ENTRIES();
 
-	if(v8js_process_globals.v8_initialized) {
+	bool v8_initialized;
+
+#ifdef ZTS
+	v8_initialized = v8js_process_globals.v8_initialized;
+#else
+	v8_initialized = V8JSG(v8_initialized);
+#endif
+
+	if(v8_initialized) {
 		v8::V8::Dispose();
 #if !defined(_WIN32) && PHP_V8_API_VERSION >= 3029036
 		v8::V8::ShutdownPlatform();

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -37,14 +37,27 @@ extern "C" {
 
 void v8js_v8_init(TSRMLS_D) /* {{{ */
 {
-	/* Run only once */
+	/* Run only once; thread-local test first */
 	if (V8JSG(v8_initialized)) {
 		return;
 	}
 
+	/* Set thread-local flag, that V8 was initialized. */
+	V8JSG(v8_initialized) = 1;
+
+#ifdef ZTS
+	v8js_process_globals.lock.lock();
+
+	if(v8js_process_globals.v8_initialized) {
+		/* V8 already has been initialized by another thread */
+		v8js_process_globals.lock.unlock();
+		return;
+	}
+#endif
+
 #if !defined(_WIN32) && PHP_V8_API_VERSION >= 3029036
-	V8JSG(v8_platform) = v8::platform::CreateDefaultPlatform();
-	v8::V8::InitializePlatform(V8JSG(v8_platform));
+	v8js_process_globals.v8_platform = v8::platform::CreateDefaultPlatform();
+	v8::V8::InitializePlatform(v8js_process_globals.v8_platform);
 #endif
 
 	/* Set V8 command line flags (must be done before V8::Initialize()!) */
@@ -55,8 +68,10 @@ void v8js_v8_init(TSRMLS_D) /* {{{ */
 	/* Initialize V8 */
 	v8::V8::Initialize();
 
-	/* Run only once */
-	V8JSG(v8_initialized) = 1;
+#ifdef ZTS
+	v8js_process_globals.v8_initialized = 1;
+	v8js_process_globals.lock.unlock();
+#endif
 }
 /* }}} */
 

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -61,8 +61,9 @@ void v8js_v8_init(TSRMLS_D) /* {{{ */
 #endif
 
 	/* Set V8 command line flags (must be done before V8::Initialize()!) */
-	if (V8JSG(v8_flags)) {
-		v8::V8::SetFlagsFromString(V8JSG(v8_flags), strlen(V8JSG(v8_flags)));
+	if (v8js_process_globals.v8_flags) {
+		v8::V8::SetFlagsFromString(v8js_process_globals.v8_flags,
+								   strlen(v8js_process_globals.v8_flags));
 	}
 
 	/* Initialize V8 */


### PR DESCRIPTION
Introduce process global struct and move initialized flag + extensions hash table there.
We must not initialize V8 twice, however pthread PECL extension creates distinct V8JS_G and hence we'd try to reinitialize