### PR TITLE
Added ability to set properties on V8Function

### DIFF
--- a/tests/function_properties.phpt
+++ b/tests/function_properties.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test V8::executeString() : Set property on function
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$v8 = new V8Js();
+
+$JS = <<< EOT
+(function(exports) {
+  // begin module code
+  exports.hello = function() { return 'hello'; };
+  // end module code
+  return exports;
+})({})
+EOT;
+
+$exports = $v8->executeString($JS, 'basic.js');
+$exports->hello->foo = "bar";
+$v8->func = $exports->hello;
+
+$v8->executeString('print(PHP.func.foo + "\n");');
+
+?>
+===EOF===
+--EXPECT--
+bar
+===EOF===

--- a/v8js_v8object_class.cc
+++ b/v8js_v8object_class.cc
@@ -63,7 +63,7 @@ static int v8js_v8object_has_property(zval *object, zval *member, int has_set_ex
 	V8JS_CTX_PROLOGUE_EX(obj->ctx, retval);
 	v8::Local<v8::Value> v8obj = v8::Local<v8::Value>::New(isolate, obj->v8obj);
 
-	if (Z_TYPE_P(member) == IS_STRING && v8obj->IsObject() && !v8obj->IsFunction())
+	if (Z_TYPE_P(member) == IS_STRING && v8obj->IsObject())
 	{
 
 		v8::Local<v8::Object> jsObj = v8obj->ToObject();
@@ -123,7 +123,7 @@ static zval *v8js_v8object_read_property(zval *object, zval *member, int type ZE
 	V8JS_CTX_PROLOGUE_EX(obj->ctx, retval);
 	v8::Local<v8::Value> v8obj = v8::Local<v8::Value>::New(isolate, obj->v8obj);
 
-	if (Z_TYPE_P(member) == IS_STRING && v8obj->IsObject() && !v8obj->IsFunction())
+	if (Z_TYPE_P(member) == IS_STRING && v8obj->IsObject())
 	{
 
 		v8::Local<v8::Object> jsObj = v8obj->ToObject();
@@ -166,7 +166,7 @@ static void v8js_v8object_write_property(zval *object, zval *member, zval *value
 	V8JS_CTX_PROLOGUE(obj->ctx);
 	v8::Local<v8::Value> v8obj = v8::Local<v8::Value>::New(isolate, obj->v8obj);
 
-	if (v8obj->IsObject() && !v8obj->IsFunction()) {
+	if (v8obj->IsObject()) {
 		v8obj->ToObject()->ForceSet(V8JS_SYML(Z_STRVAL_P(member), Z_STRLEN_P(member)), zval_to_v8js(value, isolate TSRMLS_CC));
 	}
 }
@@ -185,7 +185,7 @@ static void v8js_v8object_unset_property(zval *object, zval *member ZEND_HASH_KE
 	V8JS_CTX_PROLOGUE(obj->ctx);
 	v8::Local<v8::Value> v8obj = v8::Local<v8::Value>::New(isolate, obj->v8obj);
 
-	if (v8obj->IsObject() && !v8obj->IsFunction()) {
+	if (v8obj->IsObject()) {
 		v8obj->ToObject()->Delete(V8JS_SYML(Z_STRVAL_P(member), Z_STRLEN_P(member)));
 	}
 }


### PR DESCRIPTION
Beware: I am not a C++ programmer! But I was curious how easy it would be to fix #172 and had a look through the `v8js_v8jsobject_(has|read|write|unset)_property` code. I got wondering what would happen if I just stripped out the `&& !v8obj->IsFunction()` conditions.

And blow me, it seems to work! Maybe this is a really really bad idea, but here it is.