### PR TITLE
Fix tests/var_dump.phpt

### DIFF
--- a/v8js_methods.cc
+++ b/v8js_methods.cc
@@ -138,7 +138,7 @@ static void v8js_dumper(v8::Isolate *isolate, v8::Local<v8::Value> var, int leve
 		V8JS_GET_CLASS_NAME(cname, object);
 		int hash = object->GetIdentityHash();
 
-		if (var->IsFunction())
+		if (var->IsFunction() && strcmp(ToCString(cname), "Closure") != 0)
 		{
 			v8::String::Utf8Value csource(object->ToString());
 			php_printf("object(Closure)#%d {\n%*c%s\n", hash, level * 2 + 2, ' ', ToCString(csource));


### PR DESCRIPTION
Recent V8 versions (e.g. 4.8.253 or 4.9.19) consider `IsFunction() = true` for Closure objects from PHP; but earlier versions didn't.

This ensures consistent var_dump behaviour (sticking to the behaviour with older V8 versions).

See tests/var_dump.diff of failed test:

```
150+   object(Closure)#1647099308 {
151+       [object Closure]
150-   object(Closure)#%d (0)
```