### PR TITLE
Fix double free

### DIFF
--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -675,7 +675,7 @@ v8::Local<v8::Value> v8js_named_property_callback(v8::Local<v8::String> property
 					zval php_ret_value;
 					zend_call_method_with_2_params(&zobject, ce, &ce->__set, ZEND_SET_FUNC_NAME, &php_ret_value, &zname, &php_value);
 					ret_value = zval_to_v8js(&php_ret_value, isolate TSRMLS_CC);
-					zval_ptr_dtor(&php_value);
+					zval_ptr_dtor(&php_ret_value);
 				}
 			}
 


### PR DESCRIPTION
Fix double free of `php_value` and free `php_ret_value` instead (which otherwise would be leaked)