### PR TITLE
Don't abort PHP on fatal V8 errors, just warn about it

### DIFF
--- a/tests/extensions_circular_dependency.phpt
+++ b/tests/extensions_circular_dependency.phpt
@@ -36,4 +36,10 @@ array(2) {
   }
 }
 
-Fatal error: v8::Context::New() Circular extension dependency in %s on line 8
+Warning: Fatal V8 error in v8::Context::New(): Circular extension dependency in %s on line 8
+
+Fatal error: Uncaught V8JsException: Failed to create V8 context. Check that registered extensions do not have errors. in %s:8
+Stack trace:
+#0 %s(8): V8Js->__construct('myobj', Array, Array)
+#1 {main}
+  thrown in %s on line 8

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -301,14 +301,10 @@ static int v8js_create_ext_strarr(const char ***retval, int count, HashTable *ht
 
 static void v8js_fatal_error_handler(const char *location, const char *message) /* {{{ */
 {
-	v8::Isolate *isolate = v8::Isolate::GetCurrent();
-	if (isolate) {
-		isolate->Exit();
-	}
 	if (location) {
-		zend_error(E_ERROR, "%s %s", location, message);
+		zend_error(E_WARNING, "Fatal V8 error in %s: %s", location, message);
 	} else {
-		zend_error(E_ERROR, "%s", message);
+		zend_error(E_WARNING, "Fatal V8 error: %s", message);
 	}
 }
 /* }}} */


### PR DESCRIPTION
This way the PHP script can handle V8 errors gracefully
(and e.g. provide feedback to the user).

This especially changes behaviour when circular extension
dependencies happen (PHP code can go on, just V8 fails
to start).  This also fixes memory leaks of V8 and V8Js
itself caused by bailing out directly otherwise.