### PR TITLE
Reorder includes for Visual Studio 2015, closes #194

### DIFF
--- a/php_v8js_macros.h
+++ b/php_v8js_macros.h
@@ -18,6 +18,15 @@
 #define _GLIBCXX_USE_NANOSLEEP 1
 #endif
 
+#include <chrono>
+#include <deque>
+#include <thread>
+
+#include <map>
+#include <list>
+#include <vector>
+#include <mutex>
+
 extern "C" {
 #include "php.h"
 #include "php_v8js.h"
@@ -30,15 +39,6 @@ extern "C" {
 #endif
 
 #include <v8.h>
-
-#include <chrono>
-#include <deque>
-#include <thread>
-
-#include <map>
-#include <list>
-#include <vector>
-#include <mutex>
 
 #include "v8js_class.h"
 #include "v8js_v8.h"

--- a/v8js_array_access.cc
+++ b/v8js_array_access.cc
@@ -14,6 +14,10 @@
 #include "config.h"
 #endif
 
+#include "php_v8js_macros.h"
+#include "v8js_array_access.h"
+#include "v8js_object_export.h"
+
 extern "C" {
 #include "php.h"
 #include "ext/date/php_date.h"
@@ -21,11 +25,6 @@ extern "C" {
 #include "zend_interfaces.h"
 #include "zend_closures.h"
 }
-
-#include "php_v8js_macros.h"
-#include "v8js_array_access.h"
-#include "v8js_object_export.h"
-
 
 static zval v8js_array_access_dispatch(zend_object *object, const char *method_name, int param_count,
 									   uint32_t index, zval zvalue TSRMLS_DC) /* {{{ */

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -16,6 +16,15 @@
 #include "config.h"
 #endif
 
+#include <functional>
+#include <algorithm>
+
+#include "php_v8js_macros.h"
+#include "v8js_v8.h"
+#include "v8js_exceptions.h"
+#include "v8js_v8object_class.h"
+#include "v8js_timer.h"
+
 extern "C" {
 #include "php.h"
 #include "ext/date/php_date.h"
@@ -25,15 +34,6 @@ extern "C" {
 #include "ext/spl/spl_exceptions.h"
 #include "zend_exceptions.h"
 }
-
-#include "php_v8js_macros.h"
-#include "v8js_v8.h"
-#include "v8js_exceptions.h"
-#include "v8js_v8object_class.h"
-#include "v8js_timer.h"
-
-#include <functional>
-#include <algorithm>
 
 #define PHP_V8JS_SCRIPT_RES_NAME "V8Js script"
 

--- a/v8js_commonjs.cc
+++ b/v8js_commonjs.cc
@@ -15,12 +15,12 @@
 #include "config.h"
 #endif
 
+#include "php_v8js_macros.h"
+
 extern "C" {
 #include "php.h"
 #include "zend_exceptions.h"
 }
-
-#include "php_v8js_macros.h"
 
 static void v8js_commonjs_split_terms(const char *identifier, std::vector<char *> &terms)
 {

--- a/v8js_convert.cc
+++ b/v8js_convert.cc
@@ -15,6 +15,14 @@
 #include "config.h"
 #endif
 
+#include <stdexcept>
+#include <limits>
+
+#include "php_v8js_macros.h"
+#include "v8js_object_export.h"
+#include "v8js_v8object_class.h"
+#include "v8js_v8.h"
+
 extern "C" {
 #include "php.h"
 #include "ext/date/php_date.h"
@@ -22,14 +30,6 @@ extern "C" {
 #include "zend_interfaces.h"
 #include "zend_closures.h"
 }
-
-#include "php_v8js_macros.h"
-#include "v8js_object_export.h"
-#include "v8js_v8object_class.h"
-#include "v8js_v8.h"
-
-#include <stdexcept>
-#include <limits>
 
 static int v8js_is_assoc_array(HashTable *myht TSRMLS_DC) /* {{{ */
 {

--- a/v8js_exceptions.cc
+++ b/v8js_exceptions.cc
@@ -16,8 +16,9 @@
 #include "config.h"
 #endif
 
+#include "php_v8js_macros.h"
+
 extern "C" {
-#include "php.h"
 #include "ext/date/php_date.h"
 #include "ext/standard/php_string.h"
 #include "zend_interfaces.h"
@@ -25,9 +26,6 @@ extern "C" {
 #include "ext/spl/spl_exceptions.h"
 #include "zend_exceptions.h"
 }
-
-#include "php_v8js_macros.h"
-
 
 /* {{{ Class Entries */
 zend_class_entry *php_ce_v8js_exception;

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -15,19 +15,18 @@
 #include "config.h"
 #endif
 
+#include "php_v8js_macros.h"
+#include "v8js_array_access.h"
+#include "v8js_object_export.h"
+#include "v8js_v8object_class.h"
+
 extern "C" {
-#include "php.h"
 #include "ext/date/php_date.h"
 #include "ext/standard/php_string.h"
 #include "zend_interfaces.h"
 #include "zend_closures.h"
 #include "zend_exceptions.h"
 }
-
-#include "php_v8js_macros.h"
-#include "v8js_array_access.h"
-#include "v8js_object_export.h"
-#include "v8js_v8object_class.h"
 
 static void v8js_weak_object_callback(const v8::WeakCallbackData<v8::Object, zend_object> &data);
 

--- a/v8js_timer.cc
+++ b/v8js_timer.cc
@@ -15,7 +15,9 @@
 #include "config.h"
 #endif
 
+#ifdef _WIN32
 #include <concrt.h>
+#endif
 
 #include "php_v8js_macros.h"
 #include "v8js_v8.h"

--- a/v8js_timer.cc
+++ b/v8js_timer.cc
@@ -15,8 +15,14 @@
 #include "config.h"
 #endif
 
+#include <concrt.h>
+
+#include "php_v8js_macros.h"
+#include "v8js_v8.h"
+#include "v8js_exceptions.h"
+#include "v8js_timer.h"
+
 extern "C" {
-#include "php.h"
 #include "ext/date/php_date.h"
 #include "ext/standard/php_string.h"
 #include "zend_interfaces.h"
@@ -24,11 +30,6 @@ extern "C" {
 #include "ext/spl/spl_exceptions.h"
 #include "zend_exceptions.h"
 }
-
-#include "php_v8js_macros.h"
-#include "v8js_v8.h"
-#include "v8js_exceptions.h"
-#include "v8js_timer.h"
 
 static void v8js_timer_interrupt_handler(v8::Isolate *isolate, void *data) { /* {{{ */
 	zend_v8js_globals *globals = static_cast<zend_v8js_globals *>(data);

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -16,8 +16,12 @@
 #include "config.h"
 #endif
 
+#include "php_v8js_macros.h"
+#include "v8js_v8.h"
+#include "v8js_timer.h"
+#include "v8js_exceptions.h"
+
 extern "C" {
-#include "php.h"
 #include "ext/date/php_date.h"
 #include "ext/standard/php_string.h"
 #include "zend_interfaces.h"
@@ -28,11 +32,6 @@ extern "C" {
 #if !defined(_WIN32) && PHP_V8_API_VERSION >= 3029036
 #include <libplatform/libplatform.h>
 #endif
-
-#include "php_v8js_macros.h"
-#include "v8js_v8.h"
-#include "v8js_timer.h"
-#include "v8js_exceptions.h"
 
 void v8js_v8_init(TSRMLS_D) /* {{{ */
 {

--- a/v8js_v8object_class.cc
+++ b/v8js_v8object_class.cc
@@ -15,8 +15,12 @@
 #include "config.h"
 #endif
 
+#include "php_v8js_macros.h"
+#include "v8js_exceptions.h"
+#include "v8js_v8.h"
+#include "v8js_v8object_class.h"
+
 extern "C" {
-#include "php.h"
 #include "ext/date/php_date.h"
 #include "ext/standard/php_string.h"
 #include "zend_interfaces.h"
@@ -24,11 +28,6 @@ extern "C" {
 #include "ext/spl/spl_exceptions.h"
 #include "zend_exceptions.h"
 }
-
-#include "php_v8js_macros.h"
-#include "v8js_exceptions.h"
-#include "v8js_v8.h"
-#include "v8js_v8object_class.h"
 
 /* {{{ Class Entries */
 zend_class_entry *php_ce_v8object;

--- a/v8js_variables.cc
+++ b/v8js_variables.cc
@@ -17,13 +17,9 @@
 #include "config.h"
 #endif
 
-extern "C" {
-#include "php.h"
-}
+#include <string>
 
 #include "php_v8js_macros.h"
-#include <v8.h>
-#include <string>
 
 static void v8js_fetch_php_variable(v8::Local<v8::String> name, const v8::PropertyCallbackInfo<v8::Value>& info) /* {{{ */
 {


### PR DESCRIPTION
C++ headers need to go first, since PHP headers redefine
"inline" which causes trouble with the C++ header files.