### PR TITLE
skip extensions_error.phpt on Windows

### DIFF
--- a/tests/extensions_error.phpt
+++ b/tests/extensions_error.phpt
@@ -9,6 +9,12 @@ phpinfo(INFO_MODULES);
 $minfo = ob_get_contents();
 ob_end_clean();
 
+if(strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
+	// On Windows the "Fatal error" happens to appear before the error
+	// message output by V8 itself.
+	echo "skip Windows";
+}
+
 if(preg_match("/V8 Engine Linked Version => (.*)/", $minfo, $matches)) {
     $version = explode('.', $matches[1]);
     if($version[0] < 3 || ($version[0] == 3 && $version[1] < 30)) {


### PR DESCRIPTION
The output order on Windows differs from the test's output order on GNU/Linux and MacOS.
For the moment just skip the particular test.