### PR TITLE
Make set_time_limit tests slower

### DIFF
--- a/tests/set_time_limit_002.phpt
+++ b/tests/set_time_limit_002.phpt
@@ -11,8 +11,8 @@ var jsfunc = function() {
     var start = (new Date()).getTime();
 
     var text = "abcdefghijklmnopqrstuvwyxz0123456789";
-    while ((new Date()).getTime() - start < 500) {
-        /* pass at least 500ms in the loop so the timer loop has plenty of
+    while ((new Date()).getTime() - start < 800) {
+        /* pass at least 800ms in the loop so the timer loop has plenty of
          * time to trigger. */
 	var encoded = encodeURI(text);
     }
@@ -22,10 +22,10 @@ EOT;
 
 $v8 = new V8Js();
 /* Set very short time limit, but enough so v8 can start up safely. */
-$v8->setTimeLimit(100);
+$v8->setTimeLimit(200);
 
 $v8->incrTimeLimit = function() use ($v8) {
-    $v8->setTimeLimit(300);
+    $v8->setTimeLimit(500);
 };
 
 $func = $v8->executeString($JS);
@@ -43,5 +43,5 @@ try {
 object(V8Function)#%d (0) {
 }
 V8JsTimeLimitException
-Script time limit of 300 milliseconds exceeded
+Script time limit of 500 milliseconds exceeded
 ===EOF===

--- a/tests/set_time_limit_004.phpt
+++ b/tests/set_time_limit_004.phpt
@@ -7,7 +7,7 @@ Test V8::setTimeLimit() : Time limit can be prolonged
 
 $JS = <<< EOT
 var text = "abcdefghijklmnopqrstuvwyxz0123456789";
-/* Spend 30 * >10ms in the loop, i.e. at least 300ms; hence
+/* Spend 75 * >10ms in the loop, i.e. at least 750ms; hence
  * it should be killed if prolonging doesn't work. */
 for (var j = 0; j < 30; ++j) {
     PHP.prolongTimeLimit();
@@ -22,10 +22,10 @@ for (var j = 0; j < 30; ++j) {
 EOT;
 
 $v8 = new V8Js();
-$v8->setTimeLimit(100);
+$v8->setTimeLimit(300);
 
 $v8->prolongTimeLimit = function() use ($v8) {
-    $v8->setTimeLimit(100);
+    $v8->setTimeLimit(300);
 };
 
 $v8->executeString($JS);


### PR DESCRIPTION
... to reduce the risk of false positives on slower (or busier) boxes.