### PR TITLE
Handle V8 heap snapshots well + allow custom snapshot generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ class V8Js
 
     /**
      * Initializes and starts V8 engine and returns new V8Js object with it's own V8 context.
+     * Snapshots are supported by V8 4.3.7 and higher.
      * @param string $object_name
      * @param array $variables
      * @param array $extensions
@@ -178,6 +179,8 @@ class V8Js
 
     /**
      * Creates a custom V8 heap snapshot with the provided JavaScript source embedded.
+     * Snapshots are supported by V8 4.3.7 and higher.  For older versions of V8 this
+     * extension doesn't provide this method.
      * @param string $embed_source
      * @return string|false
      */

--- a/README.md
+++ b/README.md
@@ -62,13 +62,14 @@ class V8Js
     /* Methods */
 
     /**
-     * Initializes and starts V8 engine and Returns new V8Js object with it's own V8 context.
+     * Initializes and starts V8 engine and returns new V8Js object with it's own V8 context.
      * @param string $object_name
      * @param array $variables
      * @param array $extensions
      * @param bool $report_uncaught_exceptions
+     * @param string $snapshot_blob
      */
-    public function __construct($object_name = "PHP", array $variables = NULL, array $extensions = NULL, $report_uncaught_exceptions = TRUE)
+    public function __construct($object_name = "PHP", array $variables = [], array $extensions = [], $report_uncaught_exceptions = TRUE, $snapshot_blob = NULL)
     {}
 
     /**
@@ -173,6 +174,14 @@ class V8Js
      * @return array|string[]
      */
     public static function getExtensions()
+    {}
+
+    /**
+     * Creates a custom V8 heap snapshot with the provided JavaScript source embedded.
+     * @param string $embed_source
+     * @return string|false
+     */
+    public static function createSnapshot($embed_source)
     {}
 }
 

--- a/config.m4
+++ b/config.m4
@@ -217,7 +217,7 @@ public:
         AC_MSG_RESULT([yes])
         AC_DEFINE([PHP_V8_USE_EXTERNAL_STARTUP_DATA], [1], [Whether V8 requires (and can be provided with custom versions of) external startup data])
 
-        SEARCH_PATH="$V8_DIR/lib"
+        SEARCH_PATH="$V8_DIR/lib $V8_DIR/share/v8"
 
         AC_MSG_CHECKING([for natives_blob.bin])
         SEARCH_FOR="natives_blob.bin"

--- a/config.m4
+++ b/config.m4
@@ -130,6 +130,54 @@ int main ()
     AC_MSG_ERROR([could not determine libv8 version])
   fi
 
+  AC_MSG_CHECKING([for v8::internal::ReadNatives])
+  AC_TRY_LINK([
+    namespace v8 {
+      namespace internal {
+        void ReadNatives();
+      }
+    }], [v8::internal::ReadNatives();], [
+      AC_MSG_RESULT([found (using snapshots)])
+      AC_DEFINE([PHP_V8_USE_EXTERNAL_STARTUP_DATA], [1], [Whether V8 requires (and can be provided with custom versions of) external startup data])
+
+      SEARCH_PATH="$V8_DIR/lib"
+
+      AC_MSG_CHECKING([for natives_blob.bin])
+      SEARCH_FOR="natives_blob.bin"
+
+      for i in $SEARCH_PATH ; do
+        if test -r $i/$SEARCH_FOR; then
+          AC_MSG_RESULT([found ($i/$SEARCH_FOR)])
+          AC_DEFINE_UNQUOTED([PHP_V8_NATIVES_BLOB_PATH], "$i/$SEARCH_FOR", [Full path to natives_blob.bin file])
+          native_blob_found=1
+        fi
+      done
+
+      if test -z "$native_blob_found"; then
+        AC_MSG_RESULT([not found])
+        AC_MSG_ERROR([Please provide V8 native blob as needed])
+      fi
+
+      AC_MSG_CHECKING([for snapshot_blob.bin])
+      SEARCH_FOR="snapshot_blob.bin"
+
+      for i in $SEARCH_PATH ; do
+        if test -r $i/$SEARCH_FOR; then
+          AC_MSG_RESULT([found ($i/$SEARCH_FOR)])
+          AC_DEFINE_UNQUOTED([PHP_V8_SNAPSHOT_BLOB_PATH], "$i/$SEARCH_FOR", [Full path to snapshot_blob.bin file])
+          snapshot_blob_found=1
+        fi
+      done
+
+      if test -z "$snapshot_blob_found"; then
+        AC_MSG_RESULT([not found])
+        AC_MSG_ERROR([Please provide V8 snapshot blob as needed])
+      fi
+
+    ], [
+      AC_MSG_RESULT([not found (snapshots disabled)])
+    ])
+
   AC_LANG_RESTORE
   LIBS=$old_LIBS
   LDFLAGS=$old_LDFLAGS

--- a/tests/create_snapshot_basic.phpt
+++ b/tests/create_snapshot_basic.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Test V8Js::createSnapshot() : Basic snapshot creation & re-use
+--SKIPIF--
+<?php
+require_once(dirname(__FILE__) . '/skipif.inc');
+
+if (!method_exists('V8Js', 'createSnapshot')) {
+    die('SKIP V8Js::createSnapshot not supported');
+}
+?>
+--FILE--
+<?php
+$doublifySource = <<<EOJS
+function doublify(x) {
+    return 2 * x;
+}
+EOJS;
+
+$snap = V8Js::createSnapshot($doublifySource);
+
+if (strlen($snap) > 0) {
+    var_dump("snapshot successfully created");
+}
+
+$v8 = new V8Js('PHP', array(), array(), true, $snap);
+$v8->executeString('var_dump(doublify(23));');
+?>
+===EOF===
+--EXPECT--
+string(29) "snapshot successfully created"
+int(46)
+===EOF===

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -1122,6 +1122,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_v8js_construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, variables)
 	ZEND_ARG_INFO(0, extensions)
 	ZEND_ARG_INFO(0, report_uncaught_exceptions)
+	ZEND_ARG_INFO(0, snapshot_blob)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_v8js_sleep, 0)

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -207,9 +207,11 @@ static void v8js_free_storage(void *object TSRMLS_DC) /* {{{ */
 	c->modules_stack.~vector();
 	c->modules_base.~vector();
 
+#ifdef PHP_V8_USE_EXTERNAL_STARTUP_DATA
 	if (c->snapshot_blob.data) {
 		efree((void*)c->snapshot_blob.data);
 	}
+#endif
 
 	efree(object);
 }
@@ -368,14 +370,16 @@ static PHP_METHOD(V8Js, __construct)
 	c->create_params.array_buffer_allocator = &array_buffer_allocator;
 
 	new (&c->snapshot_blob) v8::StartupData();
+#ifdef PHP_V8_USE_EXTERNAL_STARTUP_DATA
 	if (snapshot_blob && snapshot_blob_len) {
 		c->snapshot_blob.data = snapshot_blob;
 		c->snapshot_blob.raw_size = snapshot_blob_len;
 		c->create_params.snapshot_blob = &c->snapshot_blob;
 	}
+#endif /* PHP_V8_USE_EXTERNAL_STARTUP_DATA */
 
 	c->isolate = v8::Isolate::New(c->create_params);
-#else
+#else /* PHP_V8_API_VERSION < 4004044 */
 	c->isolate = v8::Isolate::New();
 #endif
 
@@ -1077,6 +1081,7 @@ static PHP_METHOD(V8Js, getExtensions)
 }
 /* }}} */
 
+#ifdef PHP_V8_USE_EXTERNAL_STARTUP_DATA
 /* {{{ proto string|bool V8Js::createSnapshot(string embed_source)
  */
 static PHP_METHOD(V8Js, createSnapshot)
@@ -1107,6 +1112,8 @@ static PHP_METHOD(V8Js, createSnapshot)
 	delete[] snapshot_blob.data;
 }
 /* }}} */
+#endif  /* PHP_V8_USE_EXTERNAL_STARTUP_DATA */
+
 
 /* {{{ arginfo */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_v8js_construct, 0, 0, 0)
@@ -1171,9 +1178,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO(arginfo_v8js_getextensions, 0)
 ZEND_END_ARG_INFO()
 
+#ifdef PHP_V8_USE_EXTERNAL_STARTUP_DATA
 ZEND_BEGIN_ARG_INFO_EX(arginfo_v8js_createsnapshot, 0, 0, 1)
 	ZEND_ARG_INFO(0, script)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_v8js_settimelimit, 0, 0, 1)
 	ZEND_ARG_INFO(0, time_limit)
@@ -1196,11 +1205,13 @@ const zend_function_entry v8js_methods[] = { /* {{{ */
 	PHP_ME(V8Js,	clearPendingException,	arginfo_v8js_clearpendingexception,	ZEND_ACC_PUBLIC)
 	PHP_ME(V8Js,	setModuleNormaliser,	arginfo_v8js_setmodulenormaliser,	ZEND_ACC_PUBLIC)
 	PHP_ME(V8Js,	setModuleLoader,		arginfo_v8js_setmoduleloader,		ZEND_ACC_PUBLIC)
-	PHP_ME(V8Js,	registerExtension,		arginfo_v8js_registerextension,		ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-	PHP_ME(V8Js,	getExtensions,			arginfo_v8js_getextensions,			ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-	PHP_ME(V8Js,	createSnapshot,			arginfo_v8js_createsnapshot,		ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME(V8Js,	setTimeLimit,			arginfo_v8js_settimelimit,			ZEND_ACC_PUBLIC)
 	PHP_ME(V8Js,	setMemoryLimit,			arginfo_v8js_setmemorylimit,		ZEND_ACC_PUBLIC)
+	PHP_ME(V8Js,	registerExtension,		arginfo_v8js_registerextension,		ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(V8Js,	getExtensions,			arginfo_v8js_getextensions,			ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+#ifdef PHP_V8_USE_EXTERNAL_STARTUP_DATA
+	PHP_ME(V8Js,	createSnapshot,			arginfo_v8js_createsnapshot,		ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+#endif
 	{NULL, NULL, NULL}
 };
 /* }}} */

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -207,7 +207,7 @@ static void v8js_free_storage(void *object TSRMLS_DC) /* {{{ */
 	c->modules_stack.~vector();
 	c->modules_base.~vector();
 
-#ifdef PHP_V8_USE_EXTERNAL_STARTUP_DATA
+#if defined(PHP_V8_USE_EXTERNAL_STARTUP_DATA) && PHP_V8_API_VERSION >= 4004044
 	if (c->snapshot_blob.data) {
 		efree((void*)c->snapshot_blob.data);
 	}
@@ -369,8 +369,8 @@ static PHP_METHOD(V8Js, __construct)
 	new (&c->create_params) v8::Isolate::CreateParams();
 	c->create_params.array_buffer_allocator = &array_buffer_allocator;
 
-	new (&c->snapshot_blob) v8::StartupData();
 #ifdef PHP_V8_USE_EXTERNAL_STARTUP_DATA
+	new (&c->snapshot_blob) v8::StartupData();
 	if (snapshot_blob && snapshot_blob_len) {
 		c->snapshot_blob.data = snapshot_blob;
 		c->snapshot_blob.raw_size = snapshot_blob_len;

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -69,11 +69,9 @@ struct v8js_ctx {
   std::vector<struct _v8js_script *> script_objects;
   char *tz;
 
-#if PHP_V8_API_VERSION >= 4004044
+#if PHP_V8_API_VERSION >= 4003007
   v8::Isolate::CreateParams create_params;
-#ifdef PHP_V8_USE_EXTERNAL_STARTUP_DATA
   v8::StartupData snapshot_blob;
-#endif
 #endif
 
 #ifdef ZTS

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -71,6 +71,7 @@ struct v8js_ctx {
 
 #if PHP_V8_API_VERSION >= 4003007
   v8::Isolate::CreateParams create_params;
+  zval *zval_snapshot_blob;
   v8::StartupData snapshot_blob;
 #endif
 

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -2,12 +2,13 @@
   +----------------------------------------------------------------------+
   | PHP Version 5                                                        |
   +----------------------------------------------------------------------+
-  | Copyright (c) 1997-2013 The PHP Group                                |
+  | Copyright (c) 1997-2016 The PHP Group                                |
   +----------------------------------------------------------------------+
   | http://www.opensource.org/licenses/mit-license.php  MIT License      |
   +----------------------------------------------------------------------+
   | Author: Jani Taskinen <jani.taskinen@iki.fi>                         |
   | Author: Patrick Reilly <preilly@php.net>                             |
+  | Author: Stefan Siegl <stesie@php.net>                                |
   +----------------------------------------------------------------------+
 */
 
@@ -68,8 +69,13 @@ struct v8js_ctx {
   std::vector<struct _v8js_script *> script_objects;
   char *tz;
 
+#if PHP_V8_API_VERSION >= 4004044
   v8::Isolate::CreateParams create_params;
+#ifdef PHP_V8_USE_EXTERNAL_STARTUP_DATA
   v8::StartupData snapshot_blob;
+#endif
+#endif
+
 #ifdef ZTS
   void ***zts_ctx;
 #endif

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -67,6 +67,9 @@ struct v8js_ctx {
   std::vector<v8js_accessor_ctx *> accessor_list;
   std::vector<struct _v8js_script *> script_objects;
   char *tz;
+
+  v8::Isolate::CreateParams create_params;
+  v8::StartupData snapshot_blob;
 #ifdef ZTS
   void ***zts_ctx;
 #endif

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -54,6 +54,13 @@ void v8js_v8_init(TSRMLS_D) /* {{{ */
 	}
 #endif
 
+#ifdef PHP_V8_USE_EXTERNAL_STARTUP_DATA
+	v8::V8::InitializeExternalStartupData(
+		PHP_V8_NATIVES_BLOB_PATH,
+		PHP_V8_SNAPSHOT_BLOB_PATH
+	);
+#endif
+
 #if !defined(_WIN32) && PHP_V8_API_VERSION >= 3029036
 	v8js_process_globals.v8_platform = v8::platform::CreateDefaultPlatform();
 	v8::V8::InitializePlatform(v8js_process_globals.v8_platform);

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -2,7 +2,7 @@
   +----------------------------------------------------------------------+
   | PHP Version 5                                                        |
   +----------------------------------------------------------------------+
-  | Copyright (c) 1997-2015 The PHP Group                                |
+  | Copyright (c) 1997-2016 The PHP Group                                |
   +----------------------------------------------------------------------+
   | http://www.opensource.org/licenses/mit-license.php  MIT License      |
   +----------------------------------------------------------------------+
@@ -34,6 +34,43 @@ extern "C" {
 #include "v8js_timer.h"
 #include "v8js_exceptions.h"
 
+#if defined(PHP_V8_USE_EXTERNAL_STARTUP_DATA) && PHP_V8_API_VERSION < 4006076
+/* Old V8 version, requires startup data but has no
+ * (internal/API) means to let it be loaded. */
+static v8::StartupData natives_;
+static v8::StartupData snapshot_;
+
+static void v8js_v8_load_startup_data(const char* blob_file,
+									  v8::StartupData* startup_data,
+									  void (*setter_fn)(v8::StartupData*)) {
+	startup_data->data = NULL;
+	startup_data->raw_size = 0;
+
+	if (!blob_file) {
+		return;
+	}
+
+	FILE* file = fopen(blob_file, "rb");
+	if (!file) {
+		return;
+	}
+
+	fseek(file, 0, SEEK_END);
+	startup_data->raw_size = static_cast<int>(ftell(file));
+	rewind(file);
+
+	startup_data->data = new char[startup_data->raw_size];
+	int read_size = static_cast<int>(fread(const_cast<char*>(startup_data->data),
+										   1, startup_data->raw_size, file));
+	fclose(file);
+
+	if (startup_data->raw_size == read_size) {
+		(*setter_fn)(startup_data);
+	}
+}
+#endif
+
+
 void v8js_v8_init(TSRMLS_D) /* {{{ */
 {
 	/* Run only once; thread-local test first */
@@ -55,10 +92,16 @@ void v8js_v8_init(TSRMLS_D) /* {{{ */
 #endif
 
 #ifdef PHP_V8_USE_EXTERNAL_STARTUP_DATA
+	/* V8 doesn't work without startup data, load it. */
+#if PHP_V8_API_VERSION >= 4006076
 	v8::V8::InitializeExternalStartupData(
 		PHP_V8_NATIVES_BLOB_PATH,
 		PHP_V8_SNAPSHOT_BLOB_PATH
 	);
+#else
+	v8js_v8_load_startup_data(PHP_V8_NATIVES_BLOB_PATH, &natives_, v8::V8::SetNativesDataBlob);
+	v8js_v8_load_startup_data(PHP_V8_SNAPSHOT_BLOB_PATH, &snapshot_, v8::V8::SetSnapshotDataBlob);
+#endif
 #endif
 
 #if !defined(_WIN32) && PHP_V8_API_VERSION >= 3029036


### PR DESCRIPTION
* this tries to detect whether V8 has been built with snapshot generation enabled
* ... and calls `v8::V8::InitializeExternalStartupData` as needed, if yes
* adds a new static method `V8Js::createSnapshot` which creates a new heap snapshot (blob returned to caller as a string)
* allows this snapshot blob to be provided to `V8Js::__construct` as new fifth argument

This refs issue #205 