### PR TITLE
Adapt test expectations to V8 error message changes

### DIFF
--- a/tests/checkstring.phpt
+++ b/tests/checkstring.phpt
@@ -20,5 +20,5 @@ Deprecated: Function V8Js::checkString() is deprecated in %s on line %d
 bool(true)
 
 Deprecated: Function V8Js::checkString() is deprecated in %s on line %d
-string(60) "V8Js::checkString():1: SyntaxError: Unexpected token ILLEGAL"
+string(%d) "V8Js::checkString():1: SyntaxError: %s"
 ===EOF===

--- a/tests/checkstring_compile.phpt
+++ b/tests/checkstring_compile.phpt
@@ -17,5 +17,5 @@ try {
 ===EOF===
 --EXPECTF--
 resource(%d) of type (V8Js script)
-string(62) "V8Js::compileString():1: SyntaxError: Unexpected token ILLEGAL"
+string(%d) "V8Js::compileString():1: SyntaxError: %s"
 ===EOF===


### PR DESCRIPTION
V8 5.1 uses slightly changed SyntaxError messages.
This adapts our tests as needed (for support of V8 5.1 as well
as older versions)