### PR TITLE
add V8Js::setAverageObjectSize method

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ class V8Js
     {}
 
     /**
+     * Set the average object size (in bytes) for this V8Js object.
+     * V8's "amount of external memory" is adjusted by this value for every exported object.  V8 triggers a garbage collection once this totals to 192 MB.
+     * @param int $average_object_size
+     */
+    public function setAverageObjectSize($average_object_size)
+    {}
+
+    /**
      * Returns uncaught pending exception or null if there is no pending exception.
      * @return V8JsScriptException|null
      */

--- a/tests/set_average_object_size_basic.phpt
+++ b/tests/set_average_object_size_basic.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test V8::setAverageObjectSize() : Average object size can be set on V8Js object
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+$v8 = new V8Js();
+$v8->setAverageObjectSize(32768);
+
+// there's no API to query the currently announced external memory allocation,
+// hence not much we can do here...
+
+?>
+===EOF===
+--EXPECT--
+===EOF===

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -47,6 +47,7 @@ struct v8js_ctx {
   bool time_limit_hit;
   long memory_limit;
   bool memory_limit_hit;
+  long average_object_size;
 
   v8js_tmpl_t global_template;
   v8js_tmpl_t array_tmpl;

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -259,7 +259,7 @@ static void v8js_construct_callback(const v8::FunctionCallbackInfo<v8::Value>& i
 
 	// Just tell v8 that we're allocating some external memory
 	// (for the moment we just always tell 1k instead of trying to find out actual values)
-	isolate->AdjustAmountOfExternalAllocatedMemory(1024);
+	isolate->AdjustAmountOfExternalAllocatedMemory(ctx->average_object_size);
 }
 /* }}} */
 
@@ -275,7 +275,7 @@ static void v8js_weak_object_callback(const v8::WeakCallbackData<v8::Object, zva
 	ctx->weak_objects.at(value).Reset();
 	ctx->weak_objects.erase(value);
 
-	isolate->AdjustAmountOfExternalAllocatedMemory(-1024);
+	isolate->AdjustAmountOfExternalAllocatedMemory(-ctx->average_object_size);
 }
 
 static void v8js_weak_closure_callback(const v8::WeakCallbackData<v8::Object, v8js_tmpl_t> &data) {


### PR DESCRIPTION
So far the size of an object exported to V8 was assumed to be 1k flat.  If a lot of larger PHP objects were sequentially exported, then the "amount of external memory" considered by V8 is far too low and hence garbage collection due to "external memory allocation limit reached" is neither done to infrequently or never at all

The `setAverageObjectSize` method now allows to adjust this assumption