### PR TITLE
Pass back V8Object instances, don't re-wrap

### DIFF
--- a/tests/object_passback_002.phpt
+++ b/tests/object_passback_002.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test V8::executeString() : Object passing JS > PHP > JS
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$v8 = new V8Js();
+
+$v8->theApiCall = function() use ($v8) {
+	return $v8->executeString('({ foo: 23 })');
+};
+
+$v8->executeString('var_dump(PHP.theApiCall().constructor.name);');
+
+?>
+===EOF===
+--EXPECT--
+string(6) "Object"
+===EOF===

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -988,7 +988,7 @@ v8::Handle<v8::Value> v8js_hash_to_jsobj(zval *value, v8::Isolate *isolate TSRML
 	}
 
 	/* Special case, passing back object originating from JS to JS */
-	if (ce == php_ce_v8function) {
+	if (ce == php_ce_v8function || ce == php_ce_v8object) {
 		v8js_v8object *c = (v8js_v8object *) zend_object_store_get_object(value TSRMLS_CC);
 
 		if(isolate != c->ctx->isolate) {


### PR DESCRIPTION
Currently if you pass a JS object to PHP it's wrapped to a `V8Object` instance.
If you pass this `V8Object` instance back to JavaScript it's wrapped *again*, i.e. a different JS object is constructed. That is

* inconsistent with `V8Function` behaviour (where we already skip re-wrapping)
* hurts object identity
* doesn't work at all if the object is an ES6 `Promise`