### PR TITLE
Retain object identity on 'return $this'

### DIFF
--- a/tests/return_this_basic.phpt
+++ b/tests/return_this_basic.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Test V8::executeString() : return $this (aka fluent setters)
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+class Foo {
+	private $foo;
+	private $bar;
+
+	public function setFoo($value)
+	{
+		$this->foo = $value;
+		return $this;
+	}
+
+	public function setBar($value)
+	{
+		$this->bar = $value;
+		return $this;
+	}
+}
+
+$v8 = new V8Js();
+$v8->theFoo = new Foo();
+
+$v8->executeString(<<<EOJS
+	var a = PHP.theFoo.setFoo(23);
+	var b = a.setBar(42);
+
+	var_dump(PHP.theFoo === a);
+	var_dump(PHP.theFoo === b);
+EOJS
+);
+
+var_dump($v8->theFoo);
+
+?>
+===EOF===
+--EXPECTF--
+bool(true)
+bool(true)
+object(Foo)#%d (2) {
+  ["foo":"Foo":private]=>
+  int(23)
+  ["bar":"Foo":private]=>
+  int(42)
+}
+===EOF===

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -156,6 +156,9 @@ failure:
 		} else {
 			v8js_terminate_execution(isolate);
 		}
+	} else if (retval_ptr == value) {
+		// special case: "return $this"
+		return_value = info.Holder();
 	} else if (retval_ptr != NULL) {
 		return_value = zval_to_v8js(retval_ptr, isolate TSRMLS_CC);
 	}


### PR DESCRIPTION
Before this fix, if you called a "fluent" setter (i.e. one that `return $this;`) then V8Js rewrapped the object and passed that back.  That is from JS perspective object identity is *not* retained

Besides there is a strong performance impact: simple "just store that value" setters require only half the time with the fix applied.