### PR TITLE
Retain object identity on JS-side 'return this'

### DIFF
--- a/tests/return_this_001.phpt
+++ b/tests/return_this_001.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Test V8::executeString() : return this (aka fluent setters, JS-side)
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$js = <<<EOJS
+function Bar() {
+}
+
+Bar.prototype.setFoo = function(value) {
+	this.foo = value;
+	return this;
+}
+
+Bar.prototype.setBar = function(value) {
+	this.bar = value;
+	return this;
+}
+
+theBar = new Bar();
+(theBar);
+EOJS;
+
+$v8 = new V8Js();
+$bar = $v8->executeString($js);
+
+$ret = $bar->setFoo(23)->setBar(42);
+var_dump($bar === $ret);
+
+$v8->executeString('var_dump(theBar);');
+
+?>
+===EOF===
+--EXPECTF--
+bool(true)
+object(Bar)#%d (2) {
+  ["foo"] =>
+  int(23)
+  ["bar"] =>
+  int(42)
+}
+===EOF===

--- a/v8js_v8object_class.cc
+++ b/v8js_v8object_class.cc
@@ -297,7 +297,7 @@ static int v8js_v8object_call_method(char *method, INTERNAL_FUNCTION_PARAMETERS)
 		zend_get_parameters_array_ex(argc, argv);
 	}
 
-	std::function< v8::Local<v8::Value>(v8::Isolate *) > v8_call = [obj, method, argc, argv TSRMLS_CC](v8::Isolate *isolate) {
+	std::function< v8::Local<v8::Value>(v8::Isolate *) > v8_call = [obj, method, argc, argv, object, &return_value TSRMLS_CC](v8::Isolate *isolate) {
 		int i = 0;
 
 		v8::Local<v8::String> method_name = V8JS_SYML(method, strlen(method));
@@ -328,7 +328,15 @@ static int v8js_v8object_call_method(char *method, INTERNAL_FUNCTION_PARAMETERS)
 			jsArgv[i] = v8::Local<v8::Value>::New(isolate, zval_to_v8js(*argv[i], isolate TSRMLS_CC));
 		}
 
-		return cb->Call(thisObj, argc, jsArgv);
+		v8::Local<v8::Value> result = cb->Call(thisObj, argc, jsArgv);
+
+		if (obj->std.ce == php_ce_v8object && result->StrictEquals(thisObj)) {
+			/* JS code did "return this", retain object identity */
+			RETVAL_ZVAL(object, 1, 0);
+			result.Clear();
+		}
+
+		return result;
 	};
 
 	v8js_v8_call(obj->ctx, &return_value, obj->flags, obj->ctx->time_limit, obj->ctx->memory_limit, v8_call TSRMLS_CC);

--- a/v8js_v8object_class.cc
+++ b/v8js_v8object_class.cc
@@ -332,7 +332,8 @@ static int v8js_v8object_call_method(char *method, INTERNAL_FUNCTION_PARAMETERS)
 
 		if (obj->std.ce == php_ce_v8object && result->StrictEquals(thisObj)) {
 			/* JS code did "return this", retain object identity */
-			RETVAL_ZVAL(object, 1, 0);
+			ZVAL_COPY_VALUE(return_value, object);
+			zval_copy_ctor(return_value);
 			result.Clear();
 		}
 


### PR DESCRIPTION
This is like pull request #220, just the other way round

If PHP-code used JS-side "fluent setters" then the "this object" returned was wrapped into a new `V8Object` instance and so on.  This breaks object identity on PHP side and also hurts performance unnecessarily