### PR TITLE
Send LowMemoryNotification before imposing memory limit

### DIFF
--- a/v8js_timer.cc
+++ b/v8js_timer.cc
@@ -40,7 +40,8 @@ static void v8js_timer_interrupt_handler(v8::Isolate *isolate, void *data) { /* 
 
 	v8::Locker locker(isolate);
 	v8::HeapStatistics hs;
-	bool send_notification, has_sent_notification;
+	bool send_notification = false;
+	bool has_sent_notification = false;
 
 	do {
 		if (send_notification) {

--- a/v8js_timer.cc
+++ b/v8js_timer.cc
@@ -45,7 +45,11 @@ static void v8js_timer_interrupt_handler(v8::Isolate *isolate, void *data) { /* 
 
 	do {
 		if (send_notification) {
+#if PHP_V8_API_VERSION >= 3028036
 			isolate->LowMemoryNotification();
+#else
+			v8::V8::LowMemoryNotification();
+#endif
 			has_sent_notification = true;
 		}
 

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -210,7 +210,12 @@ void v8js_v8_call(v8js_ctx *c, zval **return_value,
 		isolate->GetHeapStatistics(&hs);
 
 		if (hs.used_heap_size() > memory_limit) {
-			c->memory_limit_hit = true;
+			isolate->LowMemoryNotification();
+			isolate->GetHeapStatistics(&hs);
+
+			if (hs.used_heap_size() > memory_limit) {
+				c->memory_limit_hit = true;
+			}
 		}
 	}
 

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -210,7 +210,11 @@ void v8js_v8_call(v8js_ctx *c, zval **return_value,
 		isolate->GetHeapStatistics(&hs);
 
 		if (hs.used_heap_size() > memory_limit) {
+#if PHP_V8_API_VERSION >= 3028036
 			isolate->LowMemoryNotification();
+#else
+			v8::V8::LowMemoryNotification();
+#endif
 			isolate->GetHeapStatistics(&hs);
 
 			if (hs.used_heap_size() > memory_limit) {

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -204,6 +204,16 @@ void v8js_v8_call(v8js_ctx *c, zval **return_value,
 		return;
 	}
 
+	if (memory_limit && !c->memory_limit_hit) {
+		// Re-check memory limit (very short executions might never be hit by timer thread)
+		v8::HeapStatistics hs;
+		isolate->GetHeapStatistics(&hs);
+
+		if (hs.used_heap_size() > memory_limit) {
+			c->memory_limit_hit = true;
+		}
+	}
+
 	if (c->memory_limit_hit) {
 		// Execution has been terminated due to memory limit
 		sprintf(exception_string, "Script memory limit of %lu bytes exceeded", memory_limit);


### PR DESCRIPTION
Currently if you `setMemoryLimit` the timer thread regularly checks the size of the heap and compares it against the limit.  If V8's old space is configured to be big (default is 1,5 GB) and a small limit is applied, it might happen that V8 does no garbage collection at all and V8Js considers the limit as hit.

This pull request changes the behaviour to first send a `LowMemoryNotification` to V8 in order to force a garbage collection run.  If the heap size then is still too big, then execution is terminated.

Besides this adds a memory limit check after execution which triggers if execution times are small enough never to be hit by the timer threads 10ms interval.

This fixes #217