### PR TITLE
Force to use the system-wide binutils during compilation v8

### DIFF
--- a/README.Linux.md
+++ b/README.Linux.md
@@ -53,6 +53,10 @@ export GYP_DEFINES="use_system_icu=1"
 
 # Build (with internal snapshots)
 export GYPFLAGS="-Dv8_use_external_startup_data=0"
+
+# Force gyp to use system-wide ld.gold
+export GYPFLAGS="${GYPFLAGS} -Dlinux_use_bundled_gold=0"
+
 make native library=shared snapshot=on -j8
 
 # Install to /usr


### PR DESCRIPTION
This is fixed [v8 fails to compile - 'unsupported reloc 42'](https://bbs.archlinux.org/viewtopic.php?id=209871), and maybe also future problems.