### PR TITLE
fix wrapped php object detection

### DIFF
--- a/v8js_convert.cc
+++ b/v8js_convert.cc
@@ -240,7 +240,7 @@ int v8js_to_zval(v8::Handle<v8::Value> jsValue, zval *return_value, int flags, v
 		v8::Local<v8::Object> self = jsValue->ToObject();
 
 		// if this is a wrapped PHP object, then just unwrap it.
-		if (self->InternalFieldCount()) {
+		if (self->InternalFieldCount() == 2) {
 			zval *object = reinterpret_cast<zval *>(self->GetAlignedPointerFromInternalField(1));
 			RETVAL_ZVAL(object, 1, 0);
 			return SUCCESS;

--- a/v8js_exceptions.cc
+++ b/v8js_exceptions.cc
@@ -83,7 +83,7 @@ void v8js_create_script_exception(zval *return_value, v8::Isolate *isolate, v8::
 			PHPV8_EXPROP(_string, JsTrace, stacktrace_string);
 		}
 
-		if(try_catch->Exception()->IsObject() && try_catch->Exception()->ToObject()->InternalFieldCount()) {
+		if(try_catch->Exception()->IsObject() && try_catch->Exception()->ToObject()->InternalFieldCount() == 2) {
 			zval *php_exception = reinterpret_cast<zval *>(try_catch->Exception()->ToObject()->GetAlignedPointerFromInternalField(1));
 
 			zend_class_entry *exception_ce = zend_exception_get_default(TSRMLS_C);

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -89,7 +89,7 @@ static void v8js_call_php_func(zval *value, zend_class_entry *ce, zend_function 
 		fci.params = (zval ***) safe_emalloc(argc, sizeof(zval **), 0);
 		argv = (zval **) safe_emalloc(argc, sizeof(zval *), 0);
 		for (i = 0; i < argc; i++) {
-			if (info[i]->IsObject() && info[i]->ToObject()->InternalFieldCount()) {
+			if (info[i]->IsObject() && info[i]->ToObject()->InternalFieldCount() == 2) {
 				/* This is a PHP object, passed to JS and back. */
 				argv[i] = reinterpret_cast<zval *>(info[i]->ToObject()->GetAlignedPointerFromInternalField(1));
 				Z_ADDREF_P(argv[i]);

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -276,7 +276,7 @@ int v8js_get_properties_hash(v8::Handle<v8::Value> jsValue, HashTable *retval, i
 			const char *key = ToCString(cstr);
 			zval *value = NULL;
 
-			if (jsVal->IsObject() && jsVal->ToObject()->InternalFieldCount()) {
+			if (jsVal->IsObject() && jsVal->ToObject()->InternalFieldCount() == 2) {
 				value = reinterpret_cast<zval *>(jsVal->ToObject()->GetAlignedPointerFromInternalField(1));
 				Z_ADDREF_P(value);
 			}


### PR DESCRIPTION
V8 since 5.3.337 returns InternalFieldCount() == -1 for
special objects like "arguments", which fulfilled the old
check.

closes #240