### PR TITLE
Fix build against PHP 7.1.0alpha2

### DIFF
--- a/v8js_array_access.cc
+++ b/v8js_array_access.cc
@@ -33,9 +33,11 @@ static zval v8js_array_access_dispatch(zend_object *object, const char *method_n
 	zval php_value;
 
 	fci.size = sizeof(fci);
+#if (PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION == 0)
 	fci.function_table = &object->ce->function_table;
-	ZVAL_STRING(&fci.function_name, method_name);
 	fci.symbol_table = NULL;
+#endif
+	ZVAL_STRING(&fci.function_name, method_name);
 	fci.retval = &php_value;
 
 	zval params[2];

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -55,9 +55,11 @@ static void v8js_call_php_func(zend_object *object, zend_function *method_ptr, v
 
 	/* zend_fcall_info */
 	fci.size = sizeof(fci);
+#if (PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION == 0)
 	fci.function_table = &object->ce->function_table;
-	fci.function_name = fname;
 	fci.symbol_table = NULL;
+#endif
+	fci.function_name = fname;
 	fci.object = object;
 	fci.retval = &retval;
 	fci.param_count = 0;


### PR DESCRIPTION
PHP 7.1's `zend_fcall_info` struct doesn't have `function_table` and `symbol_table` fields any longer.

This change wraps these in conditional compilation