### PR TITLE
Adapt require() exception behaviour

### DIFF
--- a/tests/commonjs_exception_001.phpt
+++ b/tests/commonjs_exception_001.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Test V8Js::setModuleLoader : Forward exceptions
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$JS = <<< EOT
+var foo = require("./test");
+EOT;
+
+$v8 = new V8Js();
+$v8->setModuleLoader(function($module) {
+    throw new Exception('some exception');
+});
+
+$v8->executeString($JS, 'module.js', V8Js::FLAG_PROPAGATE_PHP_EXCEPTIONS);
+?>
+===EOF===
+--EXPECTF--
+Fatal error: Uncaught Exception: some exception in %s%ecommonjs_exception_001.php:9
+Stack trace:
+#0 [internal function]: {closure}('test')
+#1 %s%ecommonjs_exception_001.php(12): V8Js->executeString('var foo = requi...', 'module.js', 4)
+#2 {main}
+
+Next V8JsScriptException: module.js:1: Exception: some exception in %s%ecommonjs_exception_001.php:9
+Stack trace:
+#0 [internal function]: {closure}('test')
+#1 %s%ecommonjs_exception_001.php(12): V8Js->executeString('var foo = requi...', 'module.js', 4)
+#2 {main} in %s%ecommonjs_exception_001.php:12
+Stack trace:
+#0 %s%ecommonjs_exception_001.php(12): V8Js->executeString('var foo = requi...', 'module.js', 4)
+#1 {main}
+  thrown in %s%ecommonjs_exception_001.php on line 12

--- a/tests/commonjs_exception_002.phpt
+++ b/tests/commonjs_exception_002.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test V8Js::setModuleNormaliser : Forward exceptions
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$JS = <<< EOT
+var foo = require("./test");
+EOT;
+
+$v8 = new V8Js();
+$v8->setModuleNormaliser(function($module) {
+    throw new Exception('some exception');
+});
+$v8->setModuleLoader(function($module) {
+	echo 'dummy ...';
+});
+
+$v8->executeString($JS, 'module.js', V8Js::FLAG_PROPAGATE_PHP_EXCEPTIONS);
+?>
+===EOF===
+--EXPECTF--
+Fatal error: Uncaught Exception: some exception in %s%ecommonjs_exception_002.php:9
+Stack trace:
+#0 [internal function]: {closure}('', './test')
+#1 %s%ecommonjs_exception_002.php(15): V8Js->executeString('var foo = requi...', 'module.js', 4)
+#2 {main}
+
+Next V8JsScriptException: module.js:1: Exception: some exception in %s%ecommonjs_exception_002.php:9
+Stack trace:
+#0 [internal function]: {closure}('', './test')
+#1 %s%ecommonjs_exception_002.php(15): V8Js->executeString('var foo = requi...', 'module.js', 4)
+#2 {main} in %s%ecommonjs_exception_002.php:15
+Stack trace:
+#0 %s%ecommonjs_exception_002.php(15): V8Js->executeString('var foo = requi...', 'module.js', 4)
+#1 {main}
+  thrown in %s%ecommonjs_exception_002.php on line 15

--- a/v8js_methods.cc
+++ b/v8js_methods.cc
@@ -390,9 +390,15 @@ V8JS_METHOD(require)
 		efree(normalised_module_id);
 		efree(normalised_path);
 
-		// Clear the PHP exception and throw it in V8 instead
-		zend_clear_exception(TSRMLS_C);
-		info.GetReturnValue().Set(isolate->ThrowException(V8JS_SYM("Module loader callback exception")));
+		if (c->flags & V8JS_FLAG_PROPAGATE_PHP_EXCEPTIONS) {
+			zval tmp_zv;
+			ZVAL_OBJ(&tmp_zv, EG(exception));
+			info.GetReturnValue().Set(isolate->ThrowException(zval_to_v8js(&tmp_zv, isolate)));
+			zend_clear_exception();
+		} else {
+			v8js_terminate_execution(isolate);
+		}
+
 		return;
 	}
 

--- a/v8js_methods.cc
+++ b/v8js_methods.cc
@@ -268,9 +268,14 @@ V8JS_METHOD(require)
 
 		// Check if an exception was thrown
 		if (EG(exception)) {
-			// Clear the PHP exception and throw it in V8 instead
-			zend_clear_exception(TSRMLS_C);
-			info.GetReturnValue().Set(isolate->ThrowException(V8JS_SYM("Module normaliser callback exception")));
+			if (c->flags & V8JS_FLAG_PROPAGATE_PHP_EXCEPTIONS) {
+				zval tmp_zv;
+				ZVAL_OBJ(&tmp_zv, EG(exception));
+				info.GetReturnValue().Set(isolate->ThrowException(zval_to_v8js(&tmp_zv, isolate)));
+				zend_clear_exception();
+			} else {
+				v8js_terminate_execution(isolate);
+			}
 			return;
 		}
 


### PR DESCRIPTION
Currently `executeString` et al forward exceptions to JavaScript if the `V8JS::FLAG_PROPAGATE_PHP_EXCEPTIONS`flag is set (and terminates execution otherwise). In case the exception isn't handled by JavaScript it bubbles up to PHP and the original exception is available as "previous exception"

This patch changes `require(...)` to behave exactly like that, the original exception is possibly forwarded to JavaScript (instead of the static "callback failed" being thrown before). If exception propagation isn't explicitly enabled, then the execution is simply terminated
