### PR TITLE
Make valgrind run on travis tests of v8js in php7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ php:
 env:
   - V8VER=5.2
   - V8VER=5.1
+  - V8VER=5.2 VALGRIND=1
 
 before_install: make -f Makefile.travis before_install
-install: make -f Makefile.travis install
+install:
+  - if [ "$VALGRIND" = 1 ]; then sudo apt-get install -qq valgrind; export TEST_PHP_ARGS="-m"; fi
+  - make -f Makefile.travis install
+
 script: make -f Makefile.travis test


### PR DESCRIPTION
Valgrind checks for invalid memory accesses and memory leaks.

"-m" makes php unit tests use valgrind (and malloc instead of emalloc, etc.)

See https://travis-ci.org/TysonAndre/v8js/jobs/149018507 - It takes 20 minutes. Also, tests of setting memory limits/time limits should be disabled if valgrind is detected in getenv('TEST_PHP_ARGS')

Also, the bugs I was trying to catch affects non-zts builds, and travis uses zts builds (see travis output below).

```
You are already using composer version 1.2.0 (stable channel).
$ php --version
PHP 7.0.9 (cli) (built: Jul 22 2016 14:41:38) ( ZTS )
Copyright (c) 1997-2016 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies
    with Zend OPcache v7.0.9, Copyright (c) 1999-2016, by Zend Technologies
    with Xdebug v2.4.0, Copyright (c) 2002-2016, by Derick Rethans
```