### PR TITLE
Make valgrind run on travis tests of v8js in php7 (Both ZTS and NTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,28 @@
 language: php
 sudo: required
 dist: trusty
+cache:
+  directories:
+    - $HOME/travis_cache
 
 php:
   - 7.0
   - 7.1
 
 env:
+  - V8VER=5.7
   - V8VER=5.2
   - V8VER=5.1
+  # Some bugs in v8js only show up without zts enabled.
+  # Notices with valgrind in libv8 were fixed in later v8js versions.
+  - V8VER=5.7 VALGRIND=1
+  - V8VER=5.7 VALGRIND=1 PHP_NTS_USE=1 PHP_CONFIGURE_ARGS="--disable-all --disable-zts --enable-debug" 
 
 before_install: make -f Makefile.travis before_install
-install: make -f Makefile.travis install
+install:
+  # For NTS builds: Install NTS and set the php.ini to a different blank file.
+  - if [ "x$PHP_NTS_USE" != "x" ]; then export PHP_NTS_VERSION=$(./ci/get_global_php_version.sh); echo "Version is $PHP_NTS_VERSION"; ./ci/install_php_nts.sh || exit 1; export PATH="$(./ci/generate_php_install_dir.sh)/bin:$PATH"; export PHPRC=$PWD/ci/; else ./ci/wipe_travis_cache.sh; fi
+  - if [ "$VALGRIND" = 1 ]; then sudo apt-get install -qq valgrind; export TEST_PHP_ARGS="-m"; fi
+  - make -f Makefile.travis install
+
 script: make -f Makefile.travis test

--- a/Makefile.travis
+++ b/Makefile.travis
@@ -11,9 +11,10 @@ before_install:
 install:
 	sudo apt-get install -y libv8-$(V8VER)-dev
 
+# newer releases (E.g. 5.7) of the ppa install the headers and lib to /opt/libv8-VER
 build:
 	phpize
-	./configure
+	if [ -d /opt/libv8-$(V8VER) ]; then ./configure --with-v8js=/opt/libv8-$(V8VER); else ./configure; fi
 	$(MAKE) -j3
 
 test: build

--- a/ci/generate_php_install_dir.sh
+++ b/ci/generate_php_install_dir.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -xeu
+# Print a folder name based on the integer width(32 bit or 64 bit), whether or not NTS is used (implied by PHP_CONFIGURE_ARGS), and PHP_CONFIGURE_ARGS.
+PHP_NTS_NORMAL_VERSION=${PHP_NTS_VERSION//RC[0-9]/}
+if [ "$PHP_NTS_NORMAL_VERSION" = "7.1.0" ]; then
+	PHP_NTS_NORMAL_VERSION=7.1.0RC1
+fi
+PHP_INSTALL_DIR="$HOME/travis_cache/php-$PHP_NTS_NORMAL_VERSION"
+if [ "${USE_32BIT:-0}" = "1" ]; then
+	PHP_INSTALL_DIR="$PHP_INSTALL_DIR-32bit"
+else
+	PHP_INSTALL_DIR="$PHP_INSTALL_DIR-64bit"
+fi
+if [ "$PHP_NTS_USE" = "1" ]; then
+	PHP_INSTALL_DIR="$PHP_INSTALL_DIR-nts"
+else
+	PHP_INSTALL_DIR="$PHP_INSTALL_DIR-zts"
+fi
+HASH=$(echo -n "$PHP_CONFIGURE_ARGS" | sha1sum | cut -c -4)
+PHP_INSTALL_DIR="$PHP_INSTALL_DIR-$HASH"
+echo -n "$PHP_INSTALL_DIR"

--- a/ci/get_global_php_version.sh
+++ b/ci/get_global_php_version.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+php -r "echo(preg_replace('/-dev|RC.*/','',PHP_VERSION));"

--- a/ci/install_php_nts.sh
+++ b/ci/install_php_nts.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -xeu
+
+echo "Attempting to install NTS PHP, NTS version '$PHP_NTS_VERSION'/ configure args '$PHP_CONFIGURE_ARGS'"
+if [ "x$PHP_NTS_VERSION" = "x" -o "x$PHP_CONFIGURE_ARGS" = "x" ] ; then
+	echo "Missing nts version or configuration arguments";
+	exit 1;
+fi
+PHP_FOLDER="php-$PHP_NTS_VERSION"
+PHP_INSTALL_DIR="$HOME/travis_cache/$PHP_FOLDER"
+echo "Downloading $PHP_INSTALL_DIR\n"
+if [ -x $PHP_INSTALL_DIR/bin/php ] ; then
+	echo "PHP $PHP_NTS_VERSION already installed and in cache at $HOME/travis_cache/$PHP_FOLDER";
+	exit 0
+fi
+# Remove cache if it somehow exists
+rm -rf $HOME/travis_cache/
+# Otherwise, put a minimal installation inside of the cache.
+PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
+curl --verbose https://secure.php.net/distributions/$PHP_TAR_FILE -o $PHP_TAR_FILE
+tar xjf $PHP_TAR_FILE
+pushd $PHP_FOLDER
+./configure $PHP_CONFIGURE_ARGS --prefix=$HOME/travis_cache/$PHP_FOLDER
+make -j5
+make install
+popd
+
+# Optionally, can make cached data smaller
+# If no test files have --PHPDBG--, then phpdbg can be removed
+# If no test files have --POST-- (or GET, etc), then php-cgi can be removed
+
+echo "PHP $PHP_NTS_VERSION already installed and in cache at $HOME/travis_cache/$PHP_FOLDER";

--- a/ci/php.ini
+++ b/ci/php.ini
@@ -1,0 +1,1 @@
+; Intentionally left blank.

--- a/ci/wipe_travis_cache.sh
+++ b/ci/wipe_travis_cache.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -xeu
+# Ensure that ~/travis_cache is a folder with 0 files in it.
+# This avoids accidentally caching left over files in s3.
+CACHE_DIR="$HOME/travis_cache"
+if [ -d "$CACHE_DIR" ]; then
+	if [ find "$CACHE_DIR" -mindepth 1 -print -quit | grep -q . ]; then
+		echo "$CACHE_DIR was not empty, clearing"
+		rm -rf $CACHE_DIR;
+		mkdir "$CACHE_DIR"
+	fi
+else
+	echo "$CACHE_DIR did not exist, creating an empty directory to cache"
+	mkdir "$CACHE_DIR"
+fi

--- a/tests/memory_limit.phpt
+++ b/tests/memory_limit.phpt
@@ -7,6 +7,7 @@ require_once(dirname(__FILE__) . '/skipif.inc');
 if (getenv("SKIP_SLOW_TESTS")) {
 	die("skip slow test");
 }
+skip_if_using_valgrind();
 ?>
 --FILE--
 <?php

--- a/tests/set_memory_limit_001.phpt
+++ b/tests/set_memory_limit_001.phpt
@@ -7,6 +7,7 @@ require_once(dirname(__FILE__) . '/skipif.inc');
 if (getenv("SKIP_SLOW_TESTS")) {
 	die("skip slow test");
 }
+skip_if_using_valgrind();
 ?>
 --FILE--
 <?php

--- a/tests/set_memory_limit_003.phpt
+++ b/tests/set_memory_limit_003.phpt
@@ -7,6 +7,7 @@ require_once(dirname(__FILE__) . '/skipif.inc');
 if (getenv("SKIP_SLOW_TESTS")) {
 	die("skip slow test");
 }
+skip_if_using_valgrind();
 ?>
 --FILE--
 <?php

--- a/tests/set_memory_limit_basic.phpt
+++ b/tests/set_memory_limit_basic.phpt
@@ -7,6 +7,7 @@ require_once(dirname(__FILE__) . '/skipif.inc');
 if (getenv("SKIP_SLOW_TESTS")) {
 	die("skip slow test");
 }
+skip_if_using_valgrind();
 ?>
 --FILE--
 <?php

--- a/tests/set_time_limit_001.phpt
+++ b/tests/set_time_limit_001.phpt
@@ -7,6 +7,7 @@ require_once(dirname(__FILE__) . '/skipif.inc');
 if (getenv("SKIP_SLOW_TESTS")) {
 	die("skip slow test");
 }
+skip_if_using_valgrind();
 ?>
 --FILE--
 <?php

--- a/tests/set_time_limit_002.phpt
+++ b/tests/set_time_limit_002.phpt
@@ -7,6 +7,7 @@ require_once(dirname(__FILE__) . '/skipif.inc');
 if (getenv("SKIP_SLOW_TESTS")) {
 	die("skip slow test");
 }
+skip_if_using_valgrind();
 ?>
 --FILE--
 <?php

--- a/tests/set_time_limit_003.phpt
+++ b/tests/set_time_limit_003.phpt
@@ -7,6 +7,7 @@ require_once(dirname(__FILE__) . '/skipif.inc');
 if (getenv("SKIP_SLOW_TESTS")) {
 	die("skip slow test");
 }
+skip_if_using_valgrind();
 ?>
 --FILE--
 <?php

--- a/tests/set_time_limit_004.phpt
+++ b/tests/set_time_limit_004.phpt
@@ -7,6 +7,7 @@ require_once(dirname(__FILE__) . '/skipif.inc');
 if (getenv("SKIP_SLOW_TESTS")) {
 	die("skip slow test");
 }
+skip_if_using_valgrind();
 ?>
 --FILE--
 <?php

--- a/tests/set_time_limit_basic.phpt
+++ b/tests/set_time_limit_basic.phpt
@@ -7,6 +7,7 @@ require_once(dirname(__FILE__) . '/skipif.inc');
 if (getenv("SKIP_SLOW_TESTS")) {
 	die("skip slow test");
 }
+skip_if_using_valgrind();
 ?>
 --FILE--
 <?php

--- a/tests/skipif.inc
+++ b/tests/skipif.inc
@@ -3,3 +3,17 @@
 if (!extension_loaded('v8js')) {
 	die("skip");
 }
+function skip_if_using_valgrind() {
+	// Travis encounters valgrind failures for tests of time and memory limits (even in libv8 5.7 PPA), but not able to reproduce this locally.
+	// NOTE: to debug this, try dumping *.mem if `make test` has a non-zero exit code
+	// VALGRIND_LAUNCHER doesn't exist for my env in 7.1, but 'TESTS' does
+	// Not exactly perfect to check for '-m', but close enough.
+	//
+	// Travis testing or full testing may use the environment variable TEST_PHP_ARGS
+	// But local testing may instead use TESTS
+	if (strlen($_ENV['VALGRIND_LAUNCHER'] ?? '') > 0 ||
+			in_array('-m', explode(' ', $_ENV['TESTS'] ?? '')) ||
+			in_array('-m', explode(' ', $_ENV['TEST_PHP_ARGS'] ?? ''))) {
+		die("skip test flaky on valgrind");
+	}
+}

--- a/tests/time_limit.phpt
+++ b/tests/time_limit.phpt
@@ -7,6 +7,7 @@ require_once(dirname(__FILE__) . '/skipif.inc');
 if (getenv("SKIP_SLOW_TESTS")) {
 	die("skip slow test");
 }
+skip_if_using_valgrind();
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Redid https://github.com/phpv8/v8js/pull/248

Valgrind checks for invalid memory accesses and memory leaks.

"-m" makes php unit tests use valgrind (and malloc instead of emalloc, etc.)
(Takes around 20 minutes)

Also support testing v8js with NTS (The default used by Travis is ZTS)
One of the builds will download and install PHP. This will be cached.
- This reproduces #247 on travis
- For details on travis build caching, see
  https://docs.travis-ci.com/user/caching/#Pull-request-builds-and-caches

For some reason, the memory and time limit tests sometimes fail under valgrind, but valgrind itself doesn't detect any problems. Marking those as disabled for now.
