### PR TITLE
Use an non-interned zend_string for registerExtension on ZTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ php:
 env:
   - V8VER=5.2
   - V8VER=5.1
+  - V8VER=5.2 VALGRIND=1
 
 before_install: make -f Makefile.travis before_install
-install: make -f Makefile.travis install
+install:
+  - if [ "$VALGRIND" = 1 ]; then sudo apt-get install -qq valgrind; export TEST_PHP_ARGS="-m"; fi
+  - make -f Makefile.travis install
+
 script: make -f Makefile.travis test

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -270,6 +270,7 @@ static void v8js_jsext_free_storage(v8js_jsext *jsext) /* {{{ */
 		v8js_free_ext_strarr(jsext->deps, jsext->deps_count);
 	}
 	delete jsext->extension;
+	// Free the persisted non-interned strings we allocated.
 	zend_string_release(jsext->name);
 	zend_string_release(jsext->source);
 
@@ -959,8 +960,10 @@ static int v8js_register_extension(zend_string *name, zend_string *source, zval 
 	}
 
 	jsext->auto_enable = auto_enable;
-	jsext->name = zend_string_dup(name, 1);
-	jsext->source = zend_string_dup(source, 1);
+	// Allocate a persistent string which will survive until module shutdown on both ZTS(Persistent) and NTS(Not interned, those would be cleaned up)
+	// (zend_string_dup would return the original interned string, if interned, so we don't use that)
+	jsext->name = zend_string_init(ZSTR_VAL(name), ZSTR_LEN(name), 1);
+	jsext->source = zend_string_init(ZSTR_VAL(source), ZSTR_LEN(source), 1);
 
 	if (jsext->deps) {
 		jsext->deps_ht = (HashTable *) malloc(sizeof(HashTable));


### PR DESCRIPTION
(There are no interned strings in ZTS, see the definition of
 zend_new_interned_string_int)

Fixes #247

See discussion in https://github.com/phpv8/v8js/pull/254

On NTS, strings must be **non-interned** in order to last until module shutdown. If registerExtension is passed a literal string constant, it is probably(?) interned.
ZTS doesn't have any interned strings.

Only one test has been run with valgrind(tests/extensions_basic.phpt)