### PR TITLE
README.Linux.md: Add is_component_build flag to v8gen.py command

### DIFF
--- a/README.Linux.md
+++ b/README.Linux.md
@@ -55,8 +55,7 @@ git checkout 5.6.326.12
 gclient sync
 
 # Setup GN
-tools/dev/v8gen.py -vv x64.release
-echo is_component_build = true >> out.gn/x64.release/args.gn
+tools/dev/v8gen.py -vv x64.release -- is_component_build=true
 
 # Build
 ninja -C out.gn/x64.release/


### PR DESCRIPTION
Previously, it was appended using `echo >>`. However, that wasn't picked up by `ninja` since it would've required an intermediary `gn gen out.gn/x64.release` step. By passing the additional build flag directly to `v8gen.py`, we ensure that `ninja` picks it up.

See https://github.com/10up/twentysixteenreact/issues/9 for some background.