### PR TITLE
appveyor.yml: single quotes -> double quotes (curl fails otherwise)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,17 +20,17 @@ platform:
 
 install:
   - cd %PHP_SDK%
-  - curl -fSL -o php-sdk-binary-tools-20110915.zip 'http://windows.php.net/downloads/php-sdk/php-sdk-binary-tools-20110915.zip'
+  - curl -fSL -o php-sdk-binary-tools-20110915.zip "http://windows.php.net/downloads/php-sdk/php-sdk-binary-tools-20110915.zip"
   - 7z.exe x php-sdk-binary-tools-20110915.zip
   - call bin\phpsdk_setvars.bat
   - call bin\phpsdk_buildtree.bat v8js-ci
   - cd v8js-ci\vc14\%Platform%
   - md deps
   - cd deps
-  - curl -fSL -o %V8_ASSETS% 'https://s3.amazonaws.com/win-phpv8/%V8_ASSETS%'
+  - curl -fSL -o %V8_ASSETS% "https://s3.amazonaws.com/win-phpv8/%V8_ASSETS%"
   - 7z.exe x %V8_ASSETS%
   - cd ..
-  - curl -fSL -o 'php-%PHP_VERSION%.tar.gz' 'http://us1.php.net/distributions/php-%PHP_VERSION%.tar.gz'
+  - curl -fSL -o "php-%PHP_VERSION%.tar.gz" "http://us1.php.net/distributions/php-%PHP_VERSION%.tar.gz"
   - ren php php-%PHP_VERSION%
   - 7z.exe x php-%PHP_VERSION%.tar.gz -y
   - 7z.exe x php-%PHP_VERSION%.tar -y | find /v "Extracting"


### PR DESCRIPTION
Build on appveyor started failing (without change): https://ci.appveyor.com/project/stesie/v8js/build/1.0.170/job/gvhsvmk57boi74wf