### PR TITLE
adapt module behaviour from node.js

### DIFF
--- a/tests/commonjs_node_compat_001.phpt
+++ b/tests/commonjs_node_compat_001.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test V8Js::setModuleLoader : this === module.exports
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$v8 = new V8Js();
+
+$v8->setModuleLoader(function ($moduleName) {
+    return <<<'EOJS'
+        var_dump(this === global);
+        var_dump(this === module.exports);
+EOJS
+    ;
+});
+
+$v8->executeString(<<<'EOJS'
+    var result = require('foo');
+EOJS
+);
+
+?>
+===EOF===
+--EXPECT--
+bool(false)
+bool(true)
+===EOF===

--- a/tests/commonjs_node_compat_002.phpt
+++ b/tests/commonjs_node_compat_002.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test V8Js::setModuleLoader : modules can return arbitrary values
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$v8 = new V8Js();
+
+$v8->setModuleLoader(function ($moduleName) {
+    return <<<'EOJS'
+        module.exports = 23;
+EOJS
+    ;
+});
+
+$v8->executeString(<<<'EOJS'
+    var result = require('foo');
+    var_dump(typeof result);
+    var_dump(result);
+EOJS
+);
+
+?>
+===EOF===
+--EXPECT--
+string(6) "number"
+int(23)
+===EOF===

--- a/tests/commonjs_node_compat_003.phpt
+++ b/tests/commonjs_node_compat_003.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test V8Js::setModuleLoader : delete module.exports yields undefined
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$v8 = new V8Js();
+
+$v8->setModuleLoader(function ($moduleName) {
+    return <<<'EOJS'
+        delete module.exports;
+EOJS
+    ;
+});
+
+$v8->executeString(<<<'EOJS'
+    var result = require('foo');
+    var_dump(typeof result);
+EOJS
+);
+
+?>
+===EOF===
+--EXPECT--
+string(9) "undefined"
+===EOF===

--- a/tests/commonjs_node_compat_basic.phpt
+++ b/tests/commonjs_node_compat_basic.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Test V8::executeString() : exports/module.exports behaviour
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$v8 = new V8Js();
+
+$v8->setModuleLoader(function ($moduleName) {
+    return <<<'EOJS'
+        var_dump(typeof exports);
+        var_dump(typeof module.exports);
+
+        // for compatibility both should be linked
+        var_dump(exports === module.exports);
+
+        exports = { number: 23 };
+        module.exports = { number: 42 };
+EOJS
+    ;
+});
+
+$v8->executeString(<<<'EOJS'
+    var result = require('foo');
+
+    // expect module.exports value to be picked up
+    var_dump(typeof result);
+    var_dump(result.number);
+EOJS
+);
+
+?>
+===EOF===
+--EXPECT--
+string(6) "object"
+string(6) "object"
+bool(true)
+string(6) "object"
+int(42)
+===EOF===

--- a/tests/commonjs_node_compat_basic.phpt
+++ b/tests/commonjs_node_compat_basic.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test V8::executeString() : exports/module.exports behaviour
+Test V8Js::setModuleLoader : exports/module.exports behaviour
 --SKIPIF--
 <?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
 --FILE--

--- a/tests/global_object_basic.phpt
+++ b/tests/global_object_basic.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test V8Js::executeString : Global scope links global object
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+$JS = <<< EOT
+var_dump(typeof global);
+var_dump(global.var_dump === var_dump);
+EOT;
+
+$v8 = new V8Js();
+$v8->executeString($JS);
+?>
+===EOF===
+--EXPECT--
+string(6) "object"
+bool(true)
+===EOF===

--- a/tests/global_object_basic.phpt
+++ b/tests/global_object_basic.phpt
@@ -8,6 +8,10 @@ Test V8Js::executeString : Global scope links global object
 $JS = <<< EOT
 var_dump(typeof global);
 var_dump(global.var_dump === var_dump);
+
+// also this is equal to global scope, at least in global execution context
+// (i.e. off modules)
+var_dump(this === global);
 EOT;
 
 $v8 = new V8Js();
@@ -16,5 +20,6 @@ $v8->executeString($JS);
 ===EOF===
 --EXPECT--
 string(6) "object"
+bool(true)
 bool(true)
 ===EOF===

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -182,7 +182,7 @@ static void v8js_free_storage(zend_object *object) /* {{{ */
 	c->script_objects.~vector();
 
 	/* Clear persistent handles in module cache */
-	for (std::map<char *, v8js_persistent_obj_t>::iterator it = c->modules_loaded.begin();
+	for (std::map<char *, v8js_persistent_value_t>::iterator it = c->modules_loaded.begin();
 		 it != c->modules_loaded.end(); ++it) {
 		efree(it->first);
 		it->second.Reset();
@@ -227,7 +227,7 @@ static zend_object* v8js_new(zend_class_entry *ce) /* {{{ */
 
 	new(&c->modules_stack) std::vector<char*>();
 	new(&c->modules_base) std::vector<char*>();
-	new(&c->modules_loaded) std::map<char *, v8js_persistent_obj_t, cmp_str>;
+	new(&c->modules_loaded) std::map<char *, v8js_persistent_value_t, cmp_str>;
 
 	new(&c->template_cache) std::map<const zend_string *,v8js_function_tmpl_t>();
 	new(&c->accessor_list) std::vector<v8js_accessor_ctx *>();

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -425,16 +425,14 @@ static PHP_METHOD(V8Js, __construct)
 	/* Create global template for global object */
 	// Now we are using multiple isolates this needs to be created for every context
 
-	v8::Local<v8::FunctionTemplate> tpl = v8::FunctionTemplate::New(c->isolate, 0);
-
-	tpl->SetClassName(V8JS_SYM("V8Js"));
+	v8::Local<v8::ObjectTemplate> tpl = v8::ObjectTemplate::New(c->isolate);
 	c->global_template.Reset(isolate, tpl);
 
 	/* Register builtin methods */
-	v8js_register_methods(tpl->InstanceTemplate(), c);
+	v8js_register_methods(tpl, c);
 
 	/* Create context */
-	v8::Local<v8::Context> context = v8::Context::New(isolate, &extension_conf, tpl->InstanceTemplate());
+	v8::Local<v8::Context> context = v8::Context::New(isolate, &extension_conf, tpl);
 
 	if (exts) {
 		v8js_free_ext_strarr(exts, exts_count);

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -425,14 +425,14 @@ static PHP_METHOD(V8Js, __construct)
 	/* Create global template for global object */
 	// Now we are using multiple isolates this needs to be created for every context
 
-	v8::Local<v8::ObjectTemplate> tpl = v8::ObjectTemplate::New(c->isolate);
-	c->global_template.Reset(isolate, tpl);
+	v8::Local<v8::ObjectTemplate> global_template = v8::ObjectTemplate::New(c->isolate);
+	c->global_template.Reset(isolate, global_template);
 
 	/* Register builtin methods */
-	v8js_register_methods(tpl, c);
+	v8js_register_methods(global_template, c);
 
 	/* Create context */
-	v8::Local<v8::Context> context = v8::Context::New(isolate, &extension_conf, tpl);
+	v8::Local<v8::Context> context = v8::Context::New(isolate, &extension_conf, global_template);
 
 	if (exts) {
 		v8js_free_ext_strarr(exts, exts_count);
@@ -447,6 +447,7 @@ static PHP_METHOD(V8Js, __construct)
 	}
 
 	context->SetAlignedPointerInEmbedderData(1, c);
+	context->Global()->Set(context, V8JS_SYM("global"), context->Global());
 	c->context.Reset(isolate, context);
 
 	/* Enter context */

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -18,6 +18,7 @@
 
 /* Abbreviate long type names */
 typedef v8::Persistent<v8::FunctionTemplate, v8::CopyablePersistentTraits<v8::FunctionTemplate> > v8js_function_tmpl_t;
+typedef v8::Persistent<v8::ObjectTemplate, v8::CopyablePersistentTraits<v8::ObjectTemplate> > v8js_object_tmpl_t;
 typedef v8::Persistent<v8::Object, v8::CopyablePersistentTraits<v8::Object> > v8js_persistent_obj_t;
 
 /* Forward declarations */
@@ -48,7 +49,7 @@ struct v8js_ctx {
   bool memory_limit_hit;
   long average_object_size;
 
-  v8js_function_tmpl_t global_template;
+  v8js_object_tmpl_t global_template;
   v8js_function_tmpl_t array_tmpl;
 
   zval module_normaliser;

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -17,7 +17,7 @@
 
 
 /* Abbreviate long type names */
-typedef v8::Persistent<v8::FunctionTemplate, v8::CopyablePersistentTraits<v8::FunctionTemplate> > v8js_tmpl_t;
+typedef v8::Persistent<v8::FunctionTemplate, v8::CopyablePersistentTraits<v8::FunctionTemplate> > v8js_function_tmpl_t;
 typedef v8::Persistent<v8::Object, v8::CopyablePersistentTraits<v8::Object> > v8js_persistent_obj_t;
 
 /* Forward declarations */
@@ -48,8 +48,8 @@ struct v8js_ctx {
   bool memory_limit_hit;
   long average_object_size;
 
-  v8js_tmpl_t global_template;
-  v8js_tmpl_t array_tmpl;
+  v8js_function_tmpl_t global_template;
+  v8js_function_tmpl_t array_tmpl;
 
   zval module_normaliser;
   zval module_loader;
@@ -57,12 +57,12 @@ struct v8js_ctx {
   std::vector<char *> modules_stack;
   std::vector<char *> modules_base;
   std::map<char *, v8js_persistent_obj_t, cmp_str> modules_loaded;
-  std::map<const zend_string *,v8js_tmpl_t> template_cache;
+  std::map<const zend_string *,v8js_function_tmpl_t> template_cache;
 
   std::map<zend_object *, v8js_persistent_obj_t> weak_objects;
-  std::map<v8js_tmpl_t *, v8js_persistent_obj_t> weak_closures;
-  std::map<v8js_tmpl_t *, v8js_tmpl_t> call_impls;
-  std::map<zend_function *, v8js_tmpl_t> method_tmpls;
+  std::map<v8js_function_tmpl_t *, v8js_persistent_obj_t> weak_closures;
+  std::map<v8js_function_tmpl_t *, v8js_function_tmpl_t> call_impls;
+  std::map<zend_function *, v8js_function_tmpl_t> method_tmpls;
 
   std::list<v8js_v8object *> v8js_v8objects;
 

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -20,6 +20,7 @@
 typedef v8::Persistent<v8::FunctionTemplate, v8::CopyablePersistentTraits<v8::FunctionTemplate> > v8js_function_tmpl_t;
 typedef v8::Persistent<v8::ObjectTemplate, v8::CopyablePersistentTraits<v8::ObjectTemplate> > v8js_object_tmpl_t;
 typedef v8::Persistent<v8::Object, v8::CopyablePersistentTraits<v8::Object> > v8js_persistent_obj_t;
+typedef v8::Persistent<v8::Value, v8::CopyablePersistentTraits<v8::Value> > v8js_persistent_value_t;
 
 /* Forward declarations */
 struct v8js_v8object;
@@ -57,7 +58,7 @@ struct v8js_ctx {
 
   std::vector<char *> modules_stack;
   std::vector<char *> modules_base;
-  std::map<char *, v8js_persistent_obj_t, cmp_str> modules_loaded;
+  std::map<char *, v8js_persistent_value_t, cmp_str> modules_loaded;
   std::map<const zend_string *,v8js_function_tmpl_t> template_cache;
 
   std::map<zend_object *, v8js_persistent_obj_t> weak_objects;

--- a/v8js_methods.cc
+++ b/v8js_methods.cc
@@ -336,7 +336,7 @@ V8JS_METHOD(require)
 
     // If we have already loaded and cached this module then use it
 	if (c->modules_loaded.count(normalised_module_id) > 0) {
-		v8::Persistent<v8::Object> newobj;
+		v8::Persistent<v8::Value> newobj;
 		newobj.Reset(isolate, c->modules_loaded[normalised_module_id]);
 		info.GetReturnValue().Set(newobj);
 
@@ -492,12 +492,12 @@ V8JS_METHOD(require)
 		return;
 	}
 
-	v8::Local<v8::Object> newobj;
+	v8::Local<v8::Value> newobj;
 
 	// Cache the module so it doesn't need to be compiled and run again
 	// Ensure compatibility with CommonJS implementations such as NodeJS by playing nicely with module.exports and exports
 	if (module->Has(V8JS_SYM("exports"))) {
-		newobj = module->Get(V8JS_SYM("exports"))->ToObject();
+		newobj = module->Get(V8JS_SYM("exports"));
 	}
 
 	c->modules_loaded[normalised_module_id].Reset(isolate, newobj);

--- a/v8js_methods.cc
+++ b/v8js_methods.cc
@@ -462,7 +462,7 @@ V8JS_METHOD(require)
 		jsArgv[1] = module;
 
 		// actually call the module
-		v8::Local<v8::Function>::Cast(module_function)->Call(V8JS_GLOBAL(isolate), 2, jsArgv);
+		v8::Local<v8::Function>::Cast(module_function)->Call(exports, 2, jsArgv);
 	}
 
 	// Remove this module and path from the stack


### PR DESCRIPTION
changes by this commit

* initialize one single context for all modules (instead of seperate context for each module)
* provide `global` property on global scope, pointing to the global scope itself
* provide `module.exports` property (linked to `exports` like on Node.js)
* always pick up `module.exports` (ignoring "old" `exports`)
* change `this` of module to `module.exports`

closes #267 
closes #339