### PR TITLE
Appveyor enable 3 extra tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,10 @@ install:
   - cd deps
   - curl -fSL -o %V8_ASSETS% "https://s3.amazonaws.com/win-phpv8/%V8_ASSETS%"
   - 7z.exe x %V8_ASSETS%
+  - curl -fSL -o libiconv.zip "https://windows.php.net/downloads/php-sdk/deps/vc14/%Platform%/libiconv-1.15-vc14-%Platform%.zip"
+  - 7z.exe x libiconv.zip -y
+  - curl -fSL -o libxml2.zip "https://windows.php.net/downloads/php-sdk/deps/vc14/%Platform%/libxml2-2.9.8-vc14-%Platform%.zip"
+  - 7z.exe x libxml2.zip -y
   - cd ..
   - curl -fSL -o "php-%PHP_VERSION%.tar.gz" "http://us2.php.net/distributions/php-%PHP_VERSION%.tar.gz"
   - ren php php-%PHP_VERSION%
@@ -63,7 +67,7 @@ build_script:
   - echo Building PHP [%PHP_VERSION%]
   - '%PHP_SDK%\bin\phpsdk_setvars'
   - buildconf
-  - configure --disable-all --enable-cli --with-v8js %CONFIGURE_EXTRA%
+  - configure --disable-all --enable-cli --with-iconv=yes --with-libxml=yes --with-dom=yes --enable-json=static --with-v8js %CONFIGURE_EXTRA%
   - nmake
 
 after_build:

--- a/tests/extensions_error.phpt
+++ b/tests/extensions_error.phpt
@@ -9,12 +9,6 @@ phpinfo(INFO_MODULES);
 $minfo = ob_get_contents();
 ob_end_clean();
 
-if(strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
-	// On Windows the "Fatal error" happens to appear before the error
-	// message output by V8 itself.
-	echo "skip Windows";
-}
-
 if(preg_match("/V8 Engine Linked Version => (.*)/", $minfo, $matches)) {
     $version = explode('.', $matches[1]);
     if($version[0] < 5 || ($version[0] == 5 && $version[1] < 7)) {


### PR DESCRIPTION
Enable 3 extra tests on Windows.

Tested for PHP 7.2 and PHP 7.3:
https://ci.appveyor.com/project/Jan-E/v8js-rx24a/build/1.0.51

Testing for PHP 7.1 and PHP 7.0:
https://ci.appveyor.com/project/Jan-E/v8js-rx24a/build/1.0.52

The PR relies on downloads from https://windows.php.net/downloads/php-sdk/deps/vc14/
The object_dom test will be disabled once again when those downloads aren't there anymore.