### PR TITLE
Replace obsolete AC_TRY_FOO with AC_FOO_IFELSE

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -43,7 +43,7 @@ if test "$PHP_V8JS" != "no"; then
     old_CPPFLAGS=$CPPFLAGS
     AC_LANG_PUSH([C++])
     CPPFLAGS="-std="$ac_cv_v8_cstd
-    AC_TRY_RUN([int main() { return 0; }],[],[ac_cv_v8_cstd="c++0x"],[])
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[int main() { return 0; }]])],[],[ac_cv_v8_cstd="c++0x"],[])
     AC_LANG_POP([C++])
     CPPFLAGS=$old_CPPFLAGS
   ]);
@@ -53,27 +53,27 @@ if test "$PHP_V8JS" != "no"; then
     old_CXXFLAGS=$CXXFLAGS
     AC_LANG_PUSH([C++])
     CXXFLAGS="-std="$ac_cv_v8_cstd
-    AC_TRY_RUN([int main() {
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[int main() {
         struct { unsigned int x; } foo = {-1};
         (void) foo;
         return 0;
-    }], [ ac_cv_v8_narrowing="" ], [
+    }]])],[ac_cv_v8_narrowing=""],[
         CXXFLAGS="-Wno-c++11-narrowing -std="$ac_cv_v8_cstd
-        AC_TRY_RUN([int main() {
+        AC_RUN_IFELSE([AC_LANG_SOURCE([[int main() {
             struct { unsigned int x; } foo = {-1};
             (void) foo;
             return 0;
-        }], [ ac_cv_v8_narrowing="-Wno-c++11-narrowing" ], [
+        }]])],[ac_cv_v8_narrowing="-Wno-c++11-narrowing"],[
             CXXFLAGS="-Wno-narrowing -std="$ac_cv_v8_cstd
-            AC_TRY_RUN([int main() {
+            AC_RUN_IFELSE([AC_LANG_SOURCE([[int main() {
                 struct { unsigned int x; } foo = {-1};
                 (void) foo;
                 return 0;
-            }], [ ac_cv_v8_narrowing="-Wno-narrowing" ], [
+            }]])],[ac_cv_v8_narrowing="-Wno-narrowing"],[
                 AC_MSG_ERROR([cannot compile with narrowing])
-            ], [])
-        ], [])
-    ], [])
+            ],[])
+        ],[])
+    ],[])
     AC_LANG_POP([C++])
     CXXFLAGS=$old_CXXFLAGS
   ]);
@@ -117,7 +117,7 @@ if test "$PHP_V8JS" != "no"; then
   dnl
   LIBS="$LIBS $V8JS_SHARED_LIBADD"
   AC_CACHE_CHECK(for V8 version, ac_cv_v8_version, [
-AC_TRY_RUN([#include <v8.h>
+AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <v8.h>
 #include <iostream>
 #include <fstream>
 using namespace std;
@@ -132,7 +132,7 @@ int main ()
 		return 0;
 	}
 	return 1;
-}], [ac_cv_v8_version=`cat ./conftestval|awk '{print $1}'`], [ac_cv_v8_version=NONE], [ac_cv_v8_version=NONE])
+}]])],[ac_cv_v8_version=`cat ./conftestval|awk '{print $1}'`],[ac_cv_v8_version=NONE],[ac_cv_v8_version=NONE])
 ])
 
   if test "$ac_cv_v8_version" != "NONE"; then


### PR DESCRIPTION
Hello,

Autoconf made several macros obsolete including the `AC_TRY_RUN` in 2000 and since Autoconf 2.50:
http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.2

These macros should be replaced with the current `AC_FOO_IFELSE` instead.

It is fairly safe to upgrade and take the recommendation advice of autoconf upgrade manual since the upgrade should be compatible at least with PHP versions 5.4 and up, on some systems even with PHP 5.3. PHP versions from 5.4 to 7.1 require Autoconf 2.59+ and PHP 7.2+ require Autoconf 2.64+.

This patch was created with the help of the autoupdate script:
```bash
autoupdate config.m4
```

Reference docs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.59/autoconf.pdf

Thanks for considering adding this or checking it out.