### PR TITLE
Add configure.ac to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ config.status
 config.sub
 configure
 configure.in
+configure.ac
 *~
 install-sh
 libtool


### PR DESCRIPTION
Hello,

If the `phpize` script is part of the PHP 7.0 or 7.1 installation there will be generated `configure.in` file from the PHP source code as a part of the old autotools files. If the `phpize` script is from PHP 7.2 or above there will be a new `configure.ac` file generated. This file is further used to generate the configure script.

Having these files gitignored is useful when developing the extension.

Thanks.