### PR TITLE
Replace AC_LANG_SAVE, AC_LANG_CPLUSPLUS and AC_LANG_RESTORE

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -83,8 +83,7 @@ if test "$PHP_V8JS" != "no"; then
   old_LDFLAGS=$LDFLAGS
   old_CPPFLAGS=$CPPFLAGS
 
-  AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
+  AC_LANG_PUSH([C++])
 
   CPPFLAGS="$CPPFLAGS -I$V8_DIR/include -std=$ac_cv_v8_cstd"
   LDFLAGS="$LDFLAGS -L$V8_DIR/$PHP_LIBDIR"
@@ -197,7 +196,7 @@ int main ()
               [Define unless v8::ArrayBuffer::Allocator::NewDefaultAllocator is usable.])
   fi
 
-  AC_LANG_RESTORE
+  AC_LANG_POP([C++])
   LIBS=$old_LIBS
   LDFLAGS="$old_LDFLAGS"
   CPPFLAGS=$old_CPPFLAGS


### PR DESCRIPTION
Hello,

Autoconf 2.50 in 2001 made several macros obsolete. These include also macros for temporary changing the language. Instead of these the `AC_LANG_PUSH` and `AC_LANG_POP` macros should be used with later Autoconf versions.

Since PHP 5.4 to 7.1 require to have Autoconf 2.59+ and PHP 7.2 and later require Autoconf 2.64+ the upgrade is fairly safe and most systems should already be supported.

Refs:
- http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Language-Choice.html

Thanks.