### PR TITLE
Fix time zone changed notifying for V8 v.7.5 and above

### DIFF
--- a/tests/timezones.phpt
+++ b/tests/timezones.phpt
@@ -1,13 +1,22 @@
 --TEST--
 Test V8::executeString() : Check timezone handling
 --SKIPIF--
-SKIP test currently broken, see #378
-
 <?php
 if(strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 	die('SKIP TZ not handled by v8 on Windows');
 }
 require_once(dirname(__FILE__) . '/skipif.inc');
+
+ob_start(NULL, 0, PHP_OUTPUT_HANDLER_CLEANABLE | PHP_OUTPUT_HANDLER_REMOVABLE);
+phpinfo(INFO_MODULES);
+$minfo = ob_get_contents();
+ob_end_clean();
+if(preg_match("/V8 Engine Linked Version => (.*)/", $minfo, $matches)) {
+	$version = explode('.', $matches[1]);
+	if($version[0] < 7 || ($version[0] == 7 && $version[1] < 5)) {
+		die('SKIP Only for V8 version >= 7.5');
+	}
+}
 ?>
 --FILE--
 <?php
@@ -39,7 +48,7 @@ try {
 ?>
 ===EOF===
 --EXPECT--
-Thu Mar 20 2014 11:03:24 GMT+0200 (EET)
-Thu Mar 20 2014 05:03:24 GMT-0400 (EDT)
-Thu Mar 20 2014 11:03:24 GMT+0200 (EET)
+Thu Mar 20 2014 11:03:24 GMT+0200 (Eastern European Standard Time)
+Thu Mar 20 2014 05:03:24 GMT-0400 (Eastern Daylight Time)
+Thu Mar 20 2014 11:03:24 GMT+0200 (Eastern European Standard Time)
 ===EOF===

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -133,8 +133,11 @@ void v8js_v8_call(v8js_ctx *c, zval **return_value,
 			c->tz = strdup(tz);
 		}
 		else if (strcmp(c->tz, tz) != 0) {
+#if (V8_MAJOR_VERSION < 7 || (V8_MAJOR_VERSION == 7 && V8_MINOR_VERSION < 5)) && !V8JS_V8_TIME_ZONE_REDETECTION_SUPPORTED
 			v8::Date::DateTimeConfigurationChangeNotification(c->isolate);
-
+#else
+			v8::Date::DateTimeConfigurationChangeNotification(c->isolate, v8::Date::TimeZoneDetection::kRedetect);
+#endif
 			free(c->tz);
 			c->tz = strdup(tz);
 		}


### PR DESCRIPTION
Fixes #378

- modified v8::Date::DateTimeConfigurationChangeNotification to take second parameter which can be used to fix this issue
- modification is now in V8 master, so should be included in next release (>7.4)
- the fix and test are enabled when building with V8 version >=7.5
- modification in code can be enabled manually by defining V8JS_V8_TIME_ZONE_REDETECTION_SUPPORTED=1 to be able to use the fix with current V8 master

Please let me know if there's a better way to handle the compatibility with different V8 versions.