### PR TITLE
Call v8::RegisterExtension using unique_ptr

### DIFF
--- a/README.Linux.md
+++ b/README.Linux.md
@@ -55,7 +55,7 @@ git checkout 6.4.388.18
 gclient sync
 
 # Setup GN
-tools/dev/v8gen.py -vv x64.release -- is_component_build=true
+tools/dev/v8gen.py -vv x64.release -- is_component_build=true use_custom_libcxx=false
 
 # Build
 ninja -C out.gn/x64.release/

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -1069,7 +1069,7 @@ static int v8js_register_extension(zend_string *name, zend_string *source, zval 
 #endif
 
 	jsext->extension->set_auto_enable(auto_enable ? true : false);
-	v8::RegisterExtension(jsext->extension);
+	v8::RegisterExtension(std::unique_ptr<v8::Extension>(jsext->extension));
 
 	return SUCCESS;
 }


### PR DESCRIPTION
Using this fix, I was able to build v8js with v8 version 7.6.57