### PR TITLE
Remove deprecated Context versions of ToBoolean and BooleanValue

### DIFF
--- a/v8js_convert.cc
+++ b/v8js_convert.cc
@@ -212,12 +212,8 @@ int v8js_to_zval(v8::Local<v8::Value> jsValue, zval *return_value, int flags, v8
 	}
 	else if (jsValue->IsBoolean())
 	{
-		v8::Maybe<bool> value = jsValue->BooleanValue(v8_context);
-		if (value.IsNothing())
-		{
-			return FAILURE;
-		}
-		RETVAL_BOOL(value.ToChecked());
+		bool value = jsValue->BooleanValue(isolate);
+		RETVAL_BOOL(value);
 	}
 	else if (jsValue->IsInt32() || jsValue->IsUint32())
 	{

--- a/v8js_methods.cc
+++ b/v8js_methods.cc
@@ -122,15 +122,8 @@ static void v8js_dumper(v8::Isolate *isolate, v8::Local<v8::Value> var, int leve
 	}
 	if (var->IsBoolean())
 	{
-		v8::Maybe<bool> value = var->BooleanValue(v8_context);
-		if (value.IsNothing())
-		{
-			php_printf("<empty>\n");
-		}
-		else
-		{
-			php_printf("bool(%s)\n", value.FromJust() ? "true" : "false");
-		}
+		bool value = var->BooleanValue(isolate);
+		php_printf("bool(%s)\n", value ? "true" : "false");
 		return;
 	}
 

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -863,9 +863,9 @@ static void v8js_named_property_deleter(v8::Local<v8::Name> property, const v8::
 	}
 
 	v8::Isolate *isolate = info.GetIsolate();
-	v8::MaybeLocal<v8::Boolean> value = r->ToBoolean(isolate->GetEnteredContext());
+	v8::Local<v8::Boolean> value = r->ToBoolean(isolate);
 	if (!value.IsEmpty()) {
-		info.GetReturnValue().Set(value.ToLocalChecked());
+		info.GetReturnValue().Set(value);
 	}
 }
 /* }}} */

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -133,7 +133,7 @@ void v8js_v8_call(v8js_ctx *c, zval **return_value,
 			c->tz = strdup(tz);
 		}
 		else if (strcmp(c->tz, tz) != 0) {
-			v8::Date::DateTimeConfigurationChangeNotification(c->isolate);
+			c->isolate->DateTimeConfigurationChangeNotification();
 
 			free(c->tz);
 			c->tz = strdup(tz);

--- a/v8js_v8object_class.cc
+++ b/v8js_v8object_class.cc
@@ -98,7 +98,7 @@ static int v8js_v8object_has_property(zval *object, zval *member, int has_set_ex
 	}
 
 	/* empty() */
-	retval = jsVal->BooleanValue(v8_context).FromMaybe(false);
+	retval = jsVal->BooleanValue(isolate);
 
 	/* for PHP compatibility, [] should also be empty */
 	if (jsVal->IsArray() && retval) {


### PR DESCRIPTION
### Description
This PR removes the usage of deprecated v8 methods. The context versions of ToBoolean and Boolean value were removed in this [commit](https://github.com/v8/v8/commit/c76f377a990343b18953123c2726337b38c59812#diff-3dd7a0f46b1e5c1cc67921449e7180ac), which marks V8 7.6.58. The original commit referenced has deprecation comments that helped transition to the correct APIs.

### Fixes
https://github.com/phpv8/v8js/issues/425

### Testing
Was tested with the following build of V8:
Version: 7.7.299.15
Build Args: `is_official_build=true`, `is_component_build=true`, `v8_use_external_startup_data=false`, `use_custom_libcxx=false`, `is_clang=false`, `is_cfi=false`, `treat_warnings_as_errors=false`

I've also tested this with other builds, and it gives compatibility all the way up to v8 7.9. Tried with `7.9.317.33` and all tests were still passing. Tried with `8.0.426.19` and almost all tests were failing.