### PR TITLE
make it compile with PHP 7.4 on Windows

### DIFF
--- a/php_v8js_macros.h
+++ b/php_v8js_macros.h
@@ -31,7 +31,9 @@
 #include <cmath>
 
 extern "C" {
+#ifndef _WIN32
 #include "php_config.h"
+#endif
 
 /* work around incompatibilities regarding isnan() and isfinite() macros,
  * affecting PHP versions before 7.4. */

--- a/v8js_convert.cc
+++ b/v8js_convert.cc
@@ -85,7 +85,7 @@ static v8::Local<v8::Value> v8js_hash_to_jsarr(zval *value, v8::Isolate *isolate
 	if (i > 0)
 	{
 		zval *data;
-		ulong index = 0;
+		zend_ulong index = 0;
 
 #if PHP_VERSION_ID >= 70300
 		if (myht && !(GC_FLAGS(myht) & GC_IMMUTABLE))

--- a/v8js_methods.cc
+++ b/v8js_methods.cc
@@ -364,7 +364,7 @@ V8JS_METHOD(require)
 		}
 
 		zval *data;
-		ulong index = 0;
+		zend_ulong index = 0;
 
 		ZEND_HASH_FOREACH_VAL(ht, data) {
 			if (Z_TYPE_P(data) != IS_STRING) {

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -627,7 +627,7 @@ v8::Local<v8::Value> v8js_named_property_callback(v8::Local<v8::Name> property_n
 	v8js_ctx *ctx = (v8js_ctx *) isolate->GetData(0);
 	v8::String::Utf8Value cstr(isolate, property);
 	const char *name = ToCString(cstr);
-	uint name_len = cstr.length();
+	uint32_t name_len = cstr.length();
 	char *lower = estrndup(name, name_len);
 	zend_string *method_name;
 


### PR DESCRIPTION
This fixes compilation on Windows with PHP 7.4
See https://github.com/phpv8/v8js/commit/e153ff16519eb3266dafd024a2d316d84f93fb96#r38293957

The proof of the pudding:
https://phpdev.toolsforresearch.com/php-7.4.5RC1-nts-Win32-vc15-x64.htm
https://phpdev.toolsforresearch.com/php-7.4.5RC1-nts-Win32-vc15-x64.zip
