### PR TITLE
PHP 8 Support

### DIFF
--- a/v8js_array_access.cc
+++ b/v8js_array_access.cc
@@ -50,7 +50,6 @@ static zval v8js_array_access_dispatch(zend_object *object, const char *method_n
 	fci.params = params;
 
 	fci.object = object;
-	fci.no_separation = 0;
 
 	zend_call_function(&fci, NULL);
 	zval_dtor(&fci.function_name);

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -506,7 +506,7 @@ static PHP_METHOD(V8Js, __construct)
 	V8JS_GLOBAL(isolate)->DefineOwnProperty(context, object_name_js, php_obj, v8::ReadOnly);
 
 	/* Export public property values */
-	HashTable *properties = zend_std_get_properties(getThis());
+	HashTable *properties = zend_std_get_properties(Z_OBJ_P(getThis()));
 	zval *value;
 	zend_string *member;
 
@@ -1306,14 +1306,14 @@ const zend_function_entry v8js_methods[] = { /* {{{ */
 
 
 /* V8Js object handlers */
-
-static SINCE74(zval*, void) v8js_write_property(zval *object, zval *member, zval *value, void **cache_slot) /* {{{ */
+//static SINCE74(zval*, void) v8js_write_property(zval *object, zval *member, zval *value, void **cache_slot) /* {{{ */
+static SINCE74(zval*, void) v8js_write_property(zend_object *object, zend_string *member, zval *value, void **cache_slot) /* {{{ */
 {
-	v8js_ctx *c = Z_V8JS_CTX_OBJ_P(object);
+	v8js_ctx *c = Z_V8JS_CTX(object);
 	V8JS_CTX_PROLOGUE_EX(c, SINCE74(value,));
 
 	/* Check whether member is public, if so, export to V8. */
-	zend_property_info *property_info = zend_get_property_info(c->std.ce, Z_STR_P(member), 1);
+	zend_property_info *property_info = zend_get_property_info(c->std.ce, member, 1);
 	if(!property_info ||
 	   (property_info != ZEND_WRONG_PROPERTY_INFO &&
 		(property_info->flags & ZEND_ACC_PUBLIC))) {
@@ -1321,14 +1321,14 @@ static SINCE74(zval*, void) v8js_write_property(zval *object, zval *member, zval
 		v8::Local<v8::String> object_name_js = v8::Local<v8::String>::New(isolate, c->object_name);
 		v8::Local<v8::Object> jsobj = V8JS_GLOBAL(isolate)->Get(v8_context, object_name_js).ToLocalChecked()->ToObject(v8_context).ToLocalChecked();
 
-		if (Z_STRLEN_P(member) > std::numeric_limits<int>::max()) {
+		if (ZSTR_LEN(member) > std::numeric_limits<int>::max()) {
 				zend_throw_exception(php_ce_v8js_exception,
 						"Property name exceeds maximum supported length", 0);
 				return SINCE74(value,);
 		}
 
 		/* Write value to PHP JS object */
-		v8::Local<v8::Name> key = V8JS_SYML(Z_STRVAL_P(member), static_cast<int>(Z_STRLEN_P(member)));
+		v8::Local<v8::Name> key = V8JS_SYML(ZSTR_VAL(member), static_cast<int>(ZSTR_LEN(member)));
 		jsobj->DefineOwnProperty(v8_context, key, zval_to_v8js(value, isolate), v8::ReadOnly);
 	}
 
@@ -1336,23 +1336,23 @@ static SINCE74(zval*, void) v8js_write_property(zval *object, zval *member, zval
 	SINCE74(return,) std_object_handlers.write_property(object, member, value, NULL);
 }
 /* }}} */
-
-static void v8js_unset_property(zval *object, zval *member, void **cache_slot) /* {{{ */
+//ZEND_API void zend_std_unset_property(zend_object *object, zend_string *member, void **cache_slot);
+static void v8js_unset_property(zend_object *object, zend_string *member, void **cache_slot) /* {{{ */
 {
-	V8JS_BEGIN_CTX(c, object)
+	V8JS_BEGIN_CTX_OBJECT(c, object)
 
 	/* Global PHP JS object */
 	v8::Local<v8::String> object_name_js = v8::Local<v8::String>::New(isolate, c->object_name);
 	v8::Local<v8::Object> jsobj = V8JS_GLOBAL(isolate)->Get(v8_context, object_name_js).ToLocalChecked()->ToObject(v8_context).ToLocalChecked();
 
-	if (Z_STRLEN_P(member) > std::numeric_limits<int>::max()) {
+	if (ZSTR_LEN(member) > std::numeric_limits<int>::max()) {
 			zend_throw_exception(php_ce_v8js_exception,
 					"Property name exceeds maximum supported length", 0);
 			return;
 	}
 
 	/* Delete value from PHP JS object */
-	v8::Local<v8::Value> key = V8JS_SYML(Z_STRVAL_P(member), static_cast<int>(Z_STRLEN_P(member)));
+	v8::Local<v8::Value> key = V8JS_SYML(ZSTR_VAL(member), static_cast<int>(ZSTR_LEN(member)));
 	jsobj->Delete(v8_context, key);
 
 	/* Unset from PHP object */

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -1306,7 +1306,6 @@ const zend_function_entry v8js_methods[] = { /* {{{ */
 
 
 /* V8Js object handlers */
-//static SINCE74(zval*, void) v8js_write_property(zval *object, zval *member, zval *value, void **cache_slot) /* {{{ */
 static SINCE74(zval*, void) v8js_write_property(zend_object *object, zend_string *member, zval *value, void **cache_slot) /* {{{ */
 {
 	v8js_ctx *c = Z_V8JS_CTX(object);

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -84,6 +84,7 @@ static inline struct v8js_ctx *v8js_ctx_fetch_object(zend_object *obj) {
 }
 
 #define Z_V8JS_CTX_OBJ_P(zv) v8js_ctx_fetch_object(Z_OBJ_P(zv));
+#define Z_V8JS_CTX(object) v8js_ctx_fetch_object(object);
 
 
 PHP_MINIT_FUNCTION(v8js_class);

--- a/v8js_convert.cc
+++ b/v8js_convert.cc
@@ -148,7 +148,7 @@ v8::Local<v8::Value> zval_to_v8js(zval *value, v8::Isolate *isolate) /* {{{ */
 				 ce = php_date_get_date_ce();
 				 if (instanceof_function(Z_OBJCE_P(value), ce)) {
 					 zval dtval;
-					 zend_call_method_with_0_params(value, NULL, NULL, "getTimestamp", &dtval);
+					 zend_call_method_with_0_params(Z_OBJ_P(value), NULL, NULL, "getTimestamp", &dtval);
 					 v8::Date::New(isolate->GetEnteredContext(), ((double)Z_LVAL(dtval) * 1000.0)).ToLocal(&jsValue);
 					 zval_dtor(&dtval);
 				 } else

--- a/v8js_exceptions.cc
+++ b/v8js_exceptions.cc
@@ -51,7 +51,7 @@ void v8js_create_script_exception(zval *return_value, v8::Isolate *isolate, v8::
 	object_init_ex(return_value, php_ce_v8js_script_exception);
 
 #define PHPV8_EXPROP(type, name, value) \
-	zend_update_property##type(php_ce_v8js_script_exception, return_value, #name, sizeof(#name) - 1, value);
+	zend_update_property##type(php_ce_v8js_script_exception, Z_OBJ_P(return_value), #name, sizeof(#name) - 1, value);
 
 	if (tc_message.IsEmpty()) {
 		spprintf(&message_string, 0, "%s", exception_string);
@@ -137,7 +137,7 @@ void v8js_throw_script_exception(v8::Isolate *isolate, v8::TryCatch *try_catch) 
 		if (zend_parse_parameters_none() == FAILURE) { \
 			return; \
 		} \
-		value = zend_read_property(php_ce_v8js_script_exception, getThis(), #property, sizeof(#property) - 1, 0, &rv); \
+		value = zend_read_property(php_ce_v8js_script_exception, Z_OBJ_P( getThis() ), #property, sizeof(#property) - 1, 0, &rv); \
 		RETURN_ZVAL(value, 1, 0); \
 	}
 
@@ -168,7 +168,7 @@ V8JS_EXCEPTION_METHOD(JsSourceLine);
 
 /* {{{ proto string V8JsScriptException::getJsTrace()
  */
-V8JS_EXCEPTION_METHOD(JsTrace);	
+V8JS_EXCEPTION_METHOD(JsTrace);
 /* }}} */
 
 

--- a/v8js_methods.cc
+++ b/v8js_methods.cc
@@ -311,8 +311,8 @@ V8JS_METHOD(require)
 				ZVAL_STRING(&params[0], module_base_cstr);
 				ZVAL_STRING(&params[1], module_id);
 
-				call_result = call_user_function_ex(EG(function_table), NULL, &c->module_normaliser,
-													&normaliser_result, 2, params, 0, NULL);
+				call_result = call_user_function(EG(function_table), NULL, &c->module_normaliser,
+													&normaliser_result, 2, params);
 			}
 
 			isolate->Enter();
@@ -435,7 +435,7 @@ V8JS_METHOD(require)
 
 		zend_try {
 			ZVAL_STRING(&params[0], normalised_module_id);
-			call_result = call_user_function_ex(EG(function_table), NULL, &c->module_loader, &module_code, 1, params, 0, NULL);
+			call_result = call_user_function(EG(function_table), NULL, &c->module_loader, &module_code, 1, params);
 		}
 		zend_catch {
 			v8js_terminate_execution(isolate);
@@ -477,7 +477,7 @@ V8JS_METHOD(require)
 
 		return;
 	}
-	
+
 	if(Z_TYPE(module_code) == IS_ARRAY) {
 		v8::Local<v8::Value> newarray = zval_to_v8js(&module_code, isolate);
 		c->modules_loaded[normalised_module_id].Reset(isolate, newarray);

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -138,7 +138,6 @@ static void v8js_call_php_func(zend_object *object, zend_function *method_ptr, c
 		fci.params = NULL;
 	}
 
-	fci.no_separation = 1;
 	info.GetReturnValue().Set(V8JS_NULL);
 
 	{

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -738,7 +738,7 @@ v8::Local<v8::Value> v8js_named_property_callback(v8::Local<v8::Name> property_n
 			if(!property_info ||
 			   (property_info != ZEND_WRONG_PROPERTY_INFO &&
 				property_info->flags & ZEND_ACC_PUBLIC)) {
-				zval *property_val = zend_read_property(NULL, &zobject, name, name_len, true, &php_value);
+				zval *property_val = zend_read_property(NULL, Z_OBJ_P(&zobject), name, name_len, true, &php_value);
 				// special case uninitialized_zval_ptr and return an empty value
 				// (indicating that we don't intercept this property) if the
 				// property doesn't exist.
@@ -758,7 +758,7 @@ v8::Local<v8::Value> v8js_named_property_callback(v8::Local<v8::Name> property_n
 					 /* Allow only public methods */
 					 && ((ce->__get->common.fn_flags & ZEND_ACC_PUBLIC) != 0)) {
 				/* Okay, let's call __get. */
-				zend_call_method_with_1_params(&zobject, ce, &ce->__get, ZEND_GET_FUNC_NAME, &php_value, &zname);
+				zend_call_method_with_1_params(Z_OBJ_P(&zobject), ce, &ce->__get, ZEND_GET_FUNC_NAME, &php_value, &zname);
 				ret_value = zval_to_v8js(&php_value, isolate);
 				zval_ptr_dtor(&php_value);
 			}
@@ -773,7 +773,7 @@ v8::Local<v8::Value> v8js_named_property_callback(v8::Local<v8::Name> property_n
 				if(!property_info ||
 				   (property_info != ZEND_WRONG_PROPERTY_INFO &&
 					property_info->flags & ZEND_ACC_PUBLIC)) {
-					zend_update_property(scope, &zobject, name, name_len, &php_value);
+					zend_update_property(scope, Z_OBJ_P(&zobject), name, name_len, &php_value);
 					ret_value = set_value;
 				}
 				else if (ce->__set
@@ -781,7 +781,7 @@ v8::Local<v8::Value> v8js_named_property_callback(v8::Local<v8::Name> property_n
 						 && ((ce->__set->common.fn_flags & ZEND_ACC_PUBLIC) != 0)) {
 					/* Okay, let's call __set. */
 					zval php_ret_value;
-					zend_call_method_with_2_params(&zobject, ce, &ce->__set, ZEND_SET_FUNC_NAME, &php_ret_value, &zname, &php_value);
+					zend_call_method_with_2_params(Z_OBJ_P(&zobject), ce, &ce->__set, ZEND_SET_FUNC_NAME, &php_ret_value, &zname, &php_value);
 					ret_value = zval_to_v8js(&php_ret_value, isolate);
 					zval_ptr_dtor(&php_ret_value);
 				}
@@ -795,7 +795,7 @@ v8::Local<v8::Value> v8js_named_property_callback(v8::Local<v8::Name> property_n
 			const zend_object_handlers *h = object->handlers;
 
 			if (callback_type == V8JS_PROP_QUERY) {
-				if (h->has_property(&zobject, &zname, 0, NULL)) {
+				if (h->has_property(Z_OBJ_P(&zobject), Z_STR(zname), 0, NULL)) {
 					ret_value = V8JS_UINT(v8::None);
 				} else {
 					ret_value = v8::Local<v8::Value>(); // empty handle
@@ -806,7 +806,7 @@ v8::Local<v8::Value> v8js_named_property_callback(v8::Local<v8::Name> property_n
 				if(!property_info ||
 				   (property_info != ZEND_WRONG_PROPERTY_INFO &&
 					property_info->flags & ZEND_ACC_PUBLIC)) {
-					h->unset_property(&zobject, &zname, NULL);
+					h->unset_property(Z_OBJ_P(&zobject), Z_STR(zname), NULL);
 					ret_value = V8JS_TRUE();
 				}
 				else {

--- a/v8js_v8.h
+++ b/v8js_v8.h
@@ -82,6 +82,11 @@ int v8js_get_properties_hash(v8::Local<v8::Value> jsValue, HashTable *retval, in
 	(ctx) = Z_V8JS_CTX_OBJ_P(object); \
 	V8JS_CTX_PROLOGUE(ctx);
 
+#define V8JS_BEGIN_CTX_OBJECT(ctx, object) \
+	v8js_ctx *(ctx); \
+	(ctx) = Z_V8JS_CTX(object); \
+	V8JS_CTX_PROLOGUE(ctx);
+
 
 #if PHP_VERSION_ID < 70400
 #define SINCE74(x,y) y

--- a/v8js_v8object_class.cc
+++ b/v8js_v8object_class.cc
@@ -647,22 +647,48 @@ void v8js_v8object_create(zval *res, v8::Local<v8::Value> value, int flags, v8::
 }
 /* }}} */
 
+ZEND_BEGIN_ARG_INFO(arginfo_v8object_construct, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_v8object_sleep, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_v8object_wakup, 0)
+ZEND_END_ARG_INFO()
 
 static const zend_function_entry v8js_v8object_methods[] = { /* {{{ */
-	PHP_ME(V8Object,	__construct,			NULL,				ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
-	PHP_ME(V8Object,	__sleep,				NULL,				ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-	PHP_ME(V8Object,	__wakeup,				NULL,				ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(V8Object,	__construct,			arginfo_v8object_construct,	ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
+	PHP_ME(V8Object,	__sleep,				arginfo_v8object_sleep,		ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(V8Object,	__wakeup,				arginfo_v8object_wakup,		ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	{NULL, NULL, NULL}
 };
+
 /* }}} */
 
+ZEND_BEGIN_ARG_INFO(arginfo_v8function_construct, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_v8function_sleep, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_v8function_wakup, 0)
+ZEND_END_ARG_INFO()
+
 static const zend_function_entry v8js_v8function_methods[] = { /* {{{ */
-	PHP_ME(V8Function,	__construct,			NULL,				ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
-	PHP_ME(V8Function,	__sleep,				NULL,				ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-	PHP_ME(V8Function,	__wakeup,				NULL,				ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(V8Function,	__construct,			arginfo_v8function_construct,	ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
+	PHP_ME(V8Function,	__sleep,				arginfo_v8function_sleep,		ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(V8Function,	__wakeup,				arginfo_v8function_wakup,		ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	{NULL, NULL, NULL}
 };
 /* }}} */
+ZEND_BEGIN_ARG_INFO(arginfo_v8generator_construct, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_v8generator_sleep, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_v8generator_wakup, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_v8generator_current, 0)
 ZEND_END_ARG_INFO()
@@ -680,9 +706,9 @@ ZEND_BEGIN_ARG_INFO(arginfo_v8generator_valid, 0)
 ZEND_END_ARG_INFO()
 
 static const zend_function_entry v8js_v8generator_methods[] = { /* {{{ */
-	PHP_ME(V8Generator,	__construct,			NULL,							ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
-	PHP_ME(V8Generator,	__sleep,				NULL,							ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-	PHP_ME(V8Generator,	__wakeup,				NULL,							ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(V8Generator,	__construct,			arginfo_v8generator_construct,	ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
+	PHP_ME(V8Generator,	__sleep,				arginfo_v8generator_sleep,		ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	PHP_ME(V8Generator,	__wakeup,				arginfo_v8generator_wakup,		ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 
 	PHP_ME(V8Generator,	current,				arginfo_v8generator_current,	ZEND_ACC_PUBLIC)
 	PHP_ME(V8Generator,	key,					arginfo_v8generator_key,		ZEND_ACC_PUBLIC)

--- a/v8js_v8object_class.h
+++ b/v8js_v8object_class.h
@@ -35,6 +35,7 @@ static inline v8js_v8object *v8js_v8object_fetch_object(zend_object *obj) {
 }
 
 #define Z_V8JS_V8OBJECT_OBJ_P(zv) v8js_v8object_fetch_object(Z_OBJ_P(zv));
+#define Z_V8JS_V8OBJECT(zv) v8js_v8object_fetch_object(zv);
 
 
 /* {{{ Generator container */


### PR DESCRIPTION
Warning: I have zero C++/C skills so this was purely done via trial and error.

Reading through https://github.com/php/php-src/blob/PHP-8.0/UPGRADING.INTERNALS and googling around, I managed to get v8js compiling and _looks_ to be working.

Mostly this was due to internal API changes around the use of zend_object rather than zval. See each commit for a description on the changes. 

I also had to add `ZEND_ACC_CTOR` and `ZEND_ACC_DTOR` to `config.h` (I think that file is .gitignored). She some reason these were not defined, however once I added the following block to `config.h` I then see some "already defined" type warnings later in the build. Look at https://github.com/bukka/phpc/blob/master/phpc.h#L54, this was removed in 7.4, which doesn't seem right.

```
/* ZEND_ACC_CTOR and ZEND_ACC_DTOR is removed in 7.4 */
#ifndef ZEND_ACC_CTOR
#define ZEND_ACC_CTOR 0
#endif
#ifndef ZEND_ACC_DTOR
#define ZEND_ACC_DTOR 0
#endif
```

I actually build this on the libv8-8.7 branch from @stesie, but it looks to apply cleanly to `php7`. I'm not sure if the plan is to support php7 and php8 in the same code, if so we'd need to ifdef out many places due to these API changes. IMO just going with a php8 branch might be better?