### PR TITLE
provide get_gc obj handler

### DIFF
--- a/v8js_v8object_class.cc
+++ b/v8js_v8object_class.cc
@@ -263,6 +263,14 @@ static HashTable *v8js_v8object_get_properties(zval *object) /* {{{ */
 }
 /* }}} */
 
+static HashTable *v8js_v8object_get_gc(zval *object, zval **table, int *n) /* {{{ */
+{
+	*table = NULL;
+	*n = 0;
+	return NULL;
+}
+/* }}} */
+
 static HashTable *v8js_v8object_get_debug_info(zval *object, int *is_temp) /* {{{ */
 {
 	*is_temp = 0;
@@ -828,6 +836,7 @@ PHP_MINIT_FUNCTION(v8js_v8object_class) /* {{{ */
 	v8js_v8object_handlers.get_properties = v8js_v8object_get_properties;
 	v8js_v8object_handlers.get_method = v8js_v8object_get_method;
 	v8js_v8object_handlers.call_method = v8js_v8object_call_method;
+	v8js_v8object_handlers.get_gc = v8js_v8object_get_gc;
 	v8js_v8object_handlers.get_debug_info = v8js_v8object_get_debug_info;
 	v8js_v8object_handlers.get_closure = v8js_v8object_get_closure;
 	v8js_v8object_handlers.offset = XtOffsetOf(struct v8js_v8object, std);


### PR DESCRIPTION
The `v8js_v8object_get_properties` (used to) have a check whether the garbage collector is running, and if so, was lying about the properties of a V8Object (proxy). (also used for V8Function and V8Generator)
This was ifdef'd with PHP > 7.3 since `GC_G` started to be privated from this version on... 

```cpp
static HashTable *v8js_v8object_get_properties(zval *object) /* {{{ */
{
        v8js_v8object *obj = Z_V8JS_V8OBJECT_OBJ_P(object);

        if (obj->properties == NULL) {
#if PHP_VERSION_ID < 70300
                if (GC_G(gc_active)) {
                        /* the garbage collector is running, don't create more zvals */
                        return NULL;
                }
#endif
```

What this means is, that if PHP's garbage collector kicks in (and evaluates all the objects to detect possible cycles) this extension asked V8 about the object's properties ... allocating more memory ... and possibly triggering V8's garbage collector.  The latter possibly freeing JS objects ... which in turn may reference PHP objects ... which then might get killed via `v8js_weak_object_callback` (or the closure sibling).

However PHP's garbage collector doesn't seem to handle this situation well.  Which seems obvious, since why should objects (usually) get deleted while it runs :-)

One clue was, by the way, when trying the examples from #477 ... adding `--expose-gc` flag and also repeatedly calling V8's garbage collector with `gc()` right from the JS code...

Since we don't want PHP's garbage collector to scan `V8Object` instances at all, this provides a `get_gc` handler which simply provides an empty table.

I haven't (yet) checked when the `get_gc` handler was introduced. So we might either `#ifdef` this or increase the minimum supported version to PHP 7.4 ...

@redbullmarky would you please give this patch a try? Thanks :)

Fixes #477