### PR TITLE
hold extra reference on v8 instance as long as we call into V8

### DIFF
--- a/tests/issue_472_basic.phpt
+++ b/tests/issue_472_basic.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test V8::executeString() : Issue #472 Destroy V8Js object which V8 isolate entered
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+class myjs extends \V8Js
+{
+   public function bosh()
+   {
+      $GLOBALS['v8test'] = null;
+	  unset($GLOBALS['v8test']);
+	}
+}
+
+$GLOBALS['v8test'] = new myjs('myjs');
+$ret = $GLOBALS['v8test']->executeString('
+	(() => {
+		myjs.bosh()
+	})
+');
+
+$ret();
+var_dump($ret);
+?>
+===EOF===
+--EXPECTF--
+object(V8Function)#%d (0) {
+}
+===EOF===

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -83,6 +83,10 @@ static inline struct v8js_ctx *v8js_ctx_fetch_object(zend_object *obj) {
 	return (struct v8js_ctx *)((char *)obj - XtOffsetOf(struct v8js_ctx, std));
 }
 
+static inline zend_object *v8js_ctx_to_zend_object(struct v8js_ctx *ctx) {
+	return (zend_object *)((char *)ctx + XtOffsetOf(struct v8js_ctx, std));
+}
+
 #define Z_V8JS_CTX_OBJ_P(zv) v8js_ctx_fetch_object(Z_OBJ_P(zv));
 
 


### PR DESCRIPTION
We need to make sure not to destroy the V8 isolate while it is entered (i.e. PHP code called into V8 JS code).  Since PHP code can decide to destroy the V8Js class instance any time (i.e. from PHP code called from JS, as shown in #472), ... we hence need to defer destruction until execution returns from JS back to PHP.

This PR changes `v8js_v8_call` function to increase the reference counter on `zend_object *` on enter, and decrease it on exit.


closes #472