### PR TITLE
Fix for V8 timezone notification, PHP8.x

### DIFF
--- a/tests/timezones.phpt
+++ b/tests/timezones.phpt
@@ -1,8 +1,6 @@
 --TEST--
 Test V8::executeString() : Check timezone handling
 --SKIPIF--
-SKIP test currently broken, see #378
-
 <?php
 if(strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 	die('SKIP TZ not handled by v8 on Windows');
@@ -39,7 +37,7 @@ try {
 ?>
 ===EOF===
 --EXPECT--
-Thu Mar 20 2014 11:03:24 GMT+0200 (EET)
-Thu Mar 20 2014 05:03:24 GMT-0400 (EDT)
-Thu Mar 20 2014 11:03:24 GMT+0200 (EET)
+Thu Mar 20 2014 11:03:24 GMT+0200 (Eastern European Standard Time)
+Thu Mar 20 2014 05:03:24 GMT-0400 (Eastern Daylight Time)
+Thu Mar 20 2014 11:03:24 GMT+0200 (Eastern European Standard Time)
 ===EOF===

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -148,7 +148,7 @@ void v8js_v8_call(v8js_ctx *c, zval **return_value,
 				c->tz = strdup(tz);
 			}
 			else if (strcmp(c->tz, tz) != 0) {
-				c->isolate->DateTimeConfigurationChangeNotification();
+				c->isolate->DateTimeConfigurationChangeNotification(v8::Isolate::TimeZoneDetection::kRedetect);
 
 				free(c->tz);
 				c->tz = strdup(tz);


### PR DESCRIPTION
Fixes #378 and closes #396, php8

Additional parameter supplied to DateTimeConfigurationChangeNotification as per link below; re-enabled the relevant test.

https://v8docs.nodesource.com/node-12.0/d4/df7/classv8_1_1_date.html#a85083f8170083de4389d798cbce02c44