### PR TITLE
Use Isolate-version of ScriptOrigin constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Minimum requirements
 	V8 is written in C++ and is used in Google Chrome, the open source browser from Google.
 	V8 implements ECMAScript as specified in ECMA-262, 5th edition.
 
-	This extension requires V8 7.5 or higher.
+	This extension requires V8 9.0 or higher.
 
     V8 releases are published rather quickly and the V8 team usually provides security support
     for the version line shipped with the Chrome browser (stable channel) and newer (only).

--- a/config.m4
+++ b/config.m4
@@ -140,8 +140,8 @@ int main ()
     set $ac_cv_v8_version
     IFS=$ac_IFS
     V8_API_VERSION=`expr [$]1 \* 1000000 + [$]2 \* 1000 + [$]3`
-    if test "$V8_API_VERSION" -lt 7005000 ; then
-       AC_MSG_ERROR([libv8 must be version 7.5 or greater])
+    if test "$V8_API_VERSION" -lt 9000000 ; then
+       AC_MSG_ERROR([libv8 must be version 9.0 or greater])
     fi
     AC_DEFINE_UNQUOTED([PHP_V8_API_VERSION], $V8_API_VERSION, [ ])
     AC_DEFINE_UNQUOTED([PHP_V8_VERSION], "$ac_cv_v8_version", [ ])

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -636,7 +636,7 @@ static void v8js_compile_script(zval *this_ptr, const zend_string *str, const ze
 	v8::Local<v8::String> sname = identifier
 		? V8JS_ZSTR(identifier)
 		: V8JS_SYM("V8Js::compileString()");
-	v8::ScriptOrigin origin(sname);
+	v8::ScriptOrigin origin(isolate, sname);
 
 	if (ZSTR_LEN(str) > std::numeric_limits<int>::max()) {
 		zend_throw_exception(php_ce_v8js_exception,

--- a/v8js_methods.cc
+++ b/v8js_methods.cc
@@ -516,7 +516,7 @@ V8JS_METHOD(require)
 
 	// Set script identifier
 	v8::Local<v8::String> sname = V8JS_STR(normalised_module_id);
-	v8::ScriptOrigin origin(sname);
+	v8::ScriptOrigin origin(isolate, sname);
 
 	if (Z_STRLEN(module_code) > std::numeric_limits<int>::max()) {
 		zend_throw_exception(php_ce_v8js_exception,


### PR DESCRIPTION
The new constructor was introduced with V8 9.0 and e.g. 10.1 doesn't have the old one any longer.

So in order to support 10.x versions we have to support the new version. And since 9.0 is pretty old already I've decided not to support both, but drop support for version < 9.0