### PR TITLE
Support V8 10.5

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -39,11 +39,15 @@ if test "$PHP_V8JS" != "no"; then
 
 
   AC_CACHE_CHECK(for C standard version, ac_cv_v8_cstd, [
-    ac_cv_v8_cstd="c++14"
+    ac_cv_v8_cstd="c++17"
     old_CPPFLAGS=$CPPFLAGS
     AC_LANG_PUSH([C++])
     CPPFLAGS="-std="$ac_cv_v8_cstd
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[int main() { return 0; }]])],[],[ac_cv_v8_cstd="c++1y"],[])
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[int main() { return 0; }]])],[],[
+      ac_cv_v8_cstd="c++14"
+      CPPFLAGS="-std="$ac_cv_v8_cstd
+      AC_RUN_IFELSE([AC_LANG_SOURCE([[int main() { return 0; }]])],[],[ ac_cv_v8_cstd="c++1y" ],[])
+    ],[])
     AC_LANG_POP([C++])
     CPPFLAGS=$old_CPPFLAGS
   ]);

--- a/config.m4
+++ b/config.m4
@@ -178,6 +178,24 @@ int main ()
 
 
   dnl
+  dnl  Check for v8::V8::InitializeSandbox
+  dnl
+  AC_CACHE_CHECK([for v8::V8::InitializeSandbox], ac_cv_has_initialize_sandbox, [
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([
+      #define V8_ENABLE_SANDBOX 1
+      #include <v8.h>
+    ], [ v8::V8::InitializeSandbox(); ])], [
+      ac_cv_has_initialize_sandbox=yes
+    ], [
+      ac_cv_has_initialize_sandbox=no
+    ])
+  ])
+  if test "x$ac_cv_has_initialize_sandbox" = "xyes"; then
+    AC_DEFINE([V8_HAS_INITIALIZE_SANDBOX], [1],
+              [Define if V8::InitializeSandbox must be called.])
+  fi
+
+  dnl
   dnl  Check for v8::ArrayBuffer::Allocator::NewDefaultAllocator
   dnl
   AC_CACHE_CHECK([for v8::ArrayBuffer::Allocator::NewDefaultAllocator], ac_cv_has_default_allocator, [

--- a/v8js_main.cc
+++ b/v8js_main.cc
@@ -162,7 +162,11 @@ static PHP_MSHUTDOWN_FUNCTION(v8js)
 
 	if(v8_initialized) {
 		v8::V8::Dispose();
+#if PHP_V8_API_VERSION >= 10000000
 		v8::V8::DisposePlatform();
+#else
+		v8::V8::ShutdownPlatform();
+#endif
 		// @fixme call virtual destructor somehow
 		//delete v8js_process_globals.v8_platform;
 	}

--- a/v8js_main.cc
+++ b/v8js_main.cc
@@ -162,7 +162,7 @@ static PHP_MSHUTDOWN_FUNCTION(v8js)
 
 	if(v8_initialized) {
 		v8::V8::Dispose();
-		v8::V8::ShutdownPlatform();
+		v8::V8::DisposePlatform();
 		// @fixme call virtual destructor somehow
 		//delete v8js_process_globals.v8_platform;
 	}

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -71,7 +71,7 @@ void v8js_v8_init() /* {{{ */
 	v8js_process_globals.v8_platform = v8::platform::NewDefaultPlatform();
 	v8::V8::InitializePlatform(v8js_process_globals.v8_platform.get());
 
-#ifdef V8_ENABLE_SANDBOX
+#ifdef V8_HAS_INITIALIZE_SANDBOX
 	v8::V8::InitializeSandbox();
 #endif
 

--- a/v8js_v8.cc
+++ b/v8js_v8.cc
@@ -71,6 +71,10 @@ void v8js_v8_init() /* {{{ */
 	v8js_process_globals.v8_platform = v8::platform::NewDefaultPlatform();
 	v8::V8::InitializePlatform(v8js_process_globals.v8_platform.get());
 
+#ifdef V8_ENABLE_SANDBOX
+	v8::V8::InitializeSandbox();
+#endif
+
 	/* Set V8 command line flags (must be done before V8::Initialize()!) */
 	if (v8js_process_globals.v8_flags) {
 		size_t flags_len = strlen(v8js_process_globals.v8_flags);

--- a/v8js_variables.cc
+++ b/v8js_variables.cc
@@ -80,7 +80,7 @@ void v8js_register_accessors(std::vector<v8js_accessor_ctx*> *accessor_list, v8:
         ctx->isolate = isolate;
 
 		/* Set the variable fetch callback for given symbol on named property */
-		php_obj->SetAccessor(V8JS_STRL(ZSTR_VAL(property_name), static_cast<int>(ZSTR_LEN(property_name))), v8js_fetch_php_variable, NULL, v8::External::New(isolate, ctx), v8::PROHIBITS_OVERWRITING, v8::ReadOnly, v8::AccessorSignature::New(isolate, php_obj_t));
+		php_obj->SetAccessor(V8JS_STRL(ZSTR_VAL(property_name), static_cast<int>(ZSTR_LEN(property_name))), v8js_fetch_php_variable, NULL, v8::External::New(isolate, ctx), v8::PROHIBITS_OVERWRITING, v8::ReadOnly);
 
 		/* record the context so we can free it later */
 		accessor_list->push_back(ctx);


### PR DESCRIPTION
V8 10.5 uses c++17 features (`is_lvalue_reference_v`), hence we need to adapt our config process to detect c++17 and use that (opposed to c++14 like we did before)

With that configuration works, compilation seems to pass pretty far but in the end fails with

```
/app/v8js_main.cc: In function 'int zm_shutdown_v8js(int, int)':
/app/v8js_main.cc:165:11: error: 'ShutdownPlatform' is not a member of 'v8::V8'
  165 |   v8::V8::ShutdownPlatform();
      |           ^~~~~~~~~~~~~~~~
make: *** [Makefile:218: v8js_main.lo] Error 1
```

Needs to be "investigated" where that function went to :)

refs #489 