### PR TITLE
php 8.2 compatibility

### DIFF
--- a/v8js_v8object_class.cc
+++ b/v8js_v8object_class.cc
@@ -464,7 +464,7 @@ static zend_function *v8js_v8object_get_method(zend_object **object_ptr, zend_st
 }
 /* }}} */
 
-static int v8js_v8object_get_closure(zend_object *object, zend_class_entry **ce_ptr, zend_function **fptr_ptr, zend_object **zobj_ptr, bool call) /* {{{ */
+static zend_result v8js_v8object_get_closure(zend_object *object, zend_class_entry **ce_ptr, zend_function **fptr_ptr, zend_object **zobj_ptr, bool call) /* {{{ */
 {
 	zend_internal_function *invoke;
 	v8js_v8object *obj = Z_V8JS_V8OBJECT_OBJ(object);


### PR DESCRIPTION
This is related to #492.  With this change, I'm able to get a clean compile of v8js in PHP 8.2.  The change is documented in https://github.com/php/php-src/blob/PHP-8.2/UPGRADING.INTERNALS.