### PR TITLE
Segfault fix when using empty()

### DIFF
--- a/tests/issue_504_001.phpt
+++ b/tests/issue_504_001.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test empty() : Segmentation fault caused by 'empty' check on a V8Function object
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+$v = new \V8Js();
+$r = $v->executeString('
+    a = {
+	    main: function() {}
+    };
+', null, V8Js::FLAG_FORCE_ARRAY | V8Js::FLAG_PROPAGATE_PHP_EXCEPTIONS);
+
+if (!empty($r['main'])) {
+    echo 'Ok' . PHP_EOL;
+}
+?>
+--EXPECTF--
+Ok
+

--- a/v8js_v8object_class.cc
+++ b/v8js_v8object_class.cc
@@ -916,7 +916,6 @@ PHP_MINIT_FUNCTION(v8js_v8object_class) /* {{{ */
 	/* V8<Object|Function> handlers */
 	memcpy(&v8js_v8object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 	v8js_v8object_handlers.clone_obj = NULL;
-	v8js_v8object_handlers.cast_object = NULL;
 	v8js_v8object_handlers.get_property_ptr_ptr = v8js_v8object_get_property_ptr_ptr;
 	v8js_v8object_handlers.has_property = v8js_v8object_has_property;
 	v8js_v8object_handlers.read_property = v8js_v8object_read_property;


### PR DESCRIPTION
PHP8.0 changed cast_object so that it cannot be set to NULL.

Given that `zend_get_std_object_handlers()` provides a functional default, removing the code that assigns NULL to the `cast_object` handler resolves the issue.

closes #504 
