### PR TITLE
* tests/timezones.phpt - added LC_ALL=C to prevent test failing when …

### DIFF
--- a/tests/timezones.phpt
+++ b/tests/timezones.phpt
@@ -9,6 +9,7 @@ require_once(dirname(__FILE__) . '/skipif.inc');
 ?>
 --FILE--
 <?php
+putenv('LC_ALL=C');
 
 $v8 = new V8Js();
 try {


### PR DESCRIPTION
…another locale is set as default

My LC is set to pt_BR.utf8/pt_BR, so the test always will fail without setting LC_ALL=C.
```
---- EXPECTED OUTPUT
Thu Mar 20 2014 11:03:24 GMT+0200 (Eastern European Standard Time)
Thu Mar 20 2014 05:03:24 GMT-0400 (Eastern Daylight Time)
Thu Mar 20 2014 11:03:24 GMT+0200 (Eastern European Standard Time)
===EOF===
---- ACTUAL OUTPUT
Thu Mar 20 2014 11:03:24 GMT+0200 (Horário Padrão da Europa Oriental)
Thu Mar 20 2014 05:03:24 GMT-0400 (Horário de Verão do Leste)
Thu Mar 20 2014 11:03:24 GMT+0200 (Horário Padrão da Europa Oriental)
===EOF===
---- FAILED
```

But in fact the test was a success. Setting LC_ALL=C will prevent this.