### PR TITLE
PHP 8.2 compatibility

### DIFF
--- a/tests/array_access_002.phpt
+++ b/tests/array_access_002.phpt
@@ -6,6 +6,7 @@ Test V8::executeString() : Use ArrayAccess with JavaScript native push method
 v8js.use_array_access = 1
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class MyArray implements ArrayAccess, Countable {
     private $data = Array('one', 'two', 'three');
 

--- a/tests/js-construct-protected-ctor.phpt
+++ b/tests/js-construct-protected-ctor.phpt
@@ -52,7 +52,7 @@ object(V8JsScriptException)#%d (13) {
   ["file":protected]=>
   string(%d) "%s"
   ["line":protected]=>
-  int(29)
+  int(%d)
   ["trace":"Exception":private]=>
   array(1) {
     [0]=>
@@ -60,7 +60,7 @@ object(V8JsScriptException)#%d (13) {
       ["file"]=>
       string(%d) "%s"
       ["line"]=>
-      int(29)
+      int(%d)
       ["function"]=>
       string(13) "executeString"
       ["class"]=>

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -395,7 +395,9 @@ static void v8js_named_property_enumerator(const v8::PropertyCallbackInfo<v8::Ar
 			IS_MAGIC_FUNC(ZEND_UNSET_FUNC_NAME) ||
 			IS_MAGIC_FUNC(ZEND_CALL_FUNC_NAME) ||
 			IS_MAGIC_FUNC(ZEND_INVOKE_FUNC_NAME) ||
-			IS_MAGIC_FUNC(ZEND_ISSET_FUNC_NAME)) {
+			IS_MAGIC_FUNC(ZEND_ISSET_FUNC_NAME) ||
+			IS_MAGIC_FUNC("__serialize") ||
+			IS_MAGIC_FUNC("__unserialize")) {
 			continue;
 		}
 


### PR DESCRIPTION
* tests/array_access_002.phpt - added #[AllowDynamicProperties] to the class MyArray
* tests/js-construct-protected-ctor.phpt - some change on how pph8.2 Exepctions references the line that caused the exception, when some call have multiple lines (eg: the executeString in this test), now references the line where the command started (first line) instead of the last line.
* V8Js Object Export: added to not enumerate magic methods __serialize and __unserialize - this two methods was added to DateTime objects and was causing tests/var_dump.phpt failing.
refs #501 