### PR TITLE
Update link to V8 version overview in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Minimum requirements
 
     V8 releases are published rather quickly and the V8 team usually provides security support
     for the version line shipped with the Chrome browser (stable channel) and newer (only).
-    For a version overview see https://omahaproxy.appspot.com/.
+    For a version overview see https://chromiumdash.appspot.com/branches.
 
 - PHP 8.0.0+
 


### PR DESCRIPTION
I noticed https://omahaproxy.appspot.com/ shows this message:

![Bildschirmfoto 2024-08-23 um 17 22 40](https://github.com/user-attachments/assets/09e0c52e-7230-4bde-9061-1f35d70e2a2a)

So, I figured, you could link to https://chromiumdash.appspot.com/ directly.