### PR TITLE
Improve configureless installation on debian and redhat machines

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -5,35 +5,35 @@ if test "$PHP_V8JS" != "no"; then
   SEARCH_PATH="/usr/local /usr"
   SEARCH_FOR="libv8.$SHLIB_SUFFIX_NAME"
 
-  if test -r $PHP_V8JS/$SEARCH_FOR; then
-    case $host_os in
-      darwin* )
-        # MacOS does not support --rpath
-        ;;
-      * )
-        LDFLAGS="$LDFLAGS -Wl,--rpath=$PHP_V8JS/$PHP_LIBDIR"
-        ;;
-    esac
-    V8_INCLUDE_DIR=$PHP_V8JS/include/v8
-    V8_LIBRARY_DIR=$PHP_V8JS/$PHP_LIBDIR
-  else
-    AC_MSG_CHECKING([for V8 files in default path])
-    ARCH=$(uname -m)
-
-    for i in $SEARCH_PATH ; do
-      if test -r $i/$PHP_LIBDIR/$SEARCH_FOR; then
-        V8_INCLUDE_DIR=$i/include/v8
-        V8_LIBRARY_DIR=$i/$PHP_LIBDIR
-        AC_MSG_RESULT(found in $i)
-      fi
-
-      if test -r $i/$PHP_LIBDIR/$ARCH-linux-gnu/$SEARCH_FOR; then
-        V8_INCLUDE_DIR=$i/include/v8
-        V8_LIBRARY_DIR=$i/$PHP_LIBDIR/$ARCH-linux-gnu
-        AC_MSG_RESULT(found in $i)
-      fi
-    done
+  if test -d "$PHP_V8JS"; then
+    SEARCH_PATH="$PHP_V8JS $SEARCH_PATH"
   fi
+
+  case $host_os in
+    darwin* )
+      # MacOS does not support --rpath
+      ;;
+    * )
+      LDFLAGS="$LDFLAGS -Wl,--rpath=$PHP_V8JS/$PHP_LIBDIR"
+      ;;
+  esac
+
+  AC_MSG_CHECKING([for V8 files in default path])
+  ARCH=$(uname -m)
+
+  for i in $SEARCH_PATH ; do
+    if test -r $i/$PHP_LIBDIR/$SEARCH_FOR; then
+      V8_INCLUDE_DIR=$i/include/v8
+      V8_LIBRARY_DIR=$i/$PHP_LIBDIR
+      AC_MSG_RESULT(found in $i)
+    fi
+
+    if test -r $i/$PHP_LIBDIR/$ARCH-linux-gnu/$SEARCH_FOR; then
+      V8_INCLUDE_DIR=$i/include/v8
+      V8_LIBRARY_DIR=$i/$PHP_LIBDIR/$ARCH-linux-gnu
+      AC_MSG_RESULT(found in $i)
+    fi
+  done
 
   AC_DEFINE_UNQUOTED([PHP_V8_EXEC_PATH], "$V8_LIBRARY_DIR/$SEARCH_FOR", [Full path to libv8 library file])
 

--- a/config.m4
+++ b/config.m4
@@ -18,10 +18,18 @@ if test "$PHP_V8JS" != "no"; then
     V8_LIBRARY_DIR=$PHP_V8JS/$PHP_LIBDIR
   else
     AC_MSG_CHECKING([for V8 files in default path])
+    ARCH=$(uname -m)
+
     for i in $SEARCH_PATH ; do
       if test -r $i/$PHP_LIBDIR/$SEARCH_FOR; then
         V8_INCLUDE_DIR=$i/include/v8
         V8_LIBRARY_DIR=$i/$PHP_LIBDIR
+        AC_MSG_RESULT(found in $i)
+      fi
+
+      if test -r $i/$PHP_LIBDIR/$ARCH-linux-gnu/$SEARCH_FOR; then
+        V8_INCLUDE_DIR=$i/include/v8
+        V8_LIBRARY_DIR=$i/$PHP_LIBDIR/$ARCH-linux-gnu
         AC_MSG_RESULT(found in $i)
       fi
     done

--- a/config.m4
+++ b/config.m4
@@ -28,9 +28,17 @@ if test "$PHP_V8JS" != "no"; then
       AC_MSG_RESULT(found in $i)
     fi
 
+    # Debian installations
     if test -r $i/$PHP_LIBDIR/$ARCH-linux-gnu/$SEARCH_FOR; then
       V8_INCLUDE_DIR=$i/include/v8
       V8_LIBRARY_DIR=$i/$PHP_LIBDIR/$ARCH-linux-gnu
+      AC_MSG_RESULT(found in $i)
+    fi
+
+    # Manual installations
+    if test -r $i/$PHP_LIBDIR/$SEARCH_FOR && test -r $i/include/libplatform/libplatform.h; then
+      V8_INCLUDE_DIR=$i/include
+      V8_LIBRARY_DIR=$i/$PHP_LIBDIR
       AC_MSG_RESULT(found in $i)
     fi
   done

--- a/config.m4
+++ b/config.m4
@@ -3,8 +3,8 @@ PHP_ARG_WITH(v8js, for V8 Javascript Engine,
 
 if test "$PHP_V8JS" != "no"; then
   SEARCH_PATH="/usr/local /usr"
-  SEARCH_FOR="$PHP_LIBDIR/libv8.$SHLIB_SUFFIX_NAME"
-  
+  SEARCH_FOR="libv8.$SHLIB_SUFFIX_NAME"
+
   if test -r $PHP_V8JS/$SEARCH_FOR; then
     case $host_os in
       darwin* )
@@ -14,26 +14,28 @@ if test "$PHP_V8JS" != "no"; then
         LDFLAGS="$LDFLAGS -Wl,--rpath=$PHP_V8JS/$PHP_LIBDIR"
         ;;
     esac
-    V8_DIR=$PHP_V8JS
+    V8_INCLUDE_DIR=$PHP_V8JS/include/v8
+    V8_LIBRARY_DIR=$PHP_V8JS/$PHP_LIBDIR
   else
     AC_MSG_CHECKING([for V8 files in default path])
     for i in $SEARCH_PATH ; do
-      if test -r $i/$SEARCH_FOR; then
-        V8_DIR=$i
+      if test -r $i/$PHP_LIBDIR/$SEARCH_FOR; then
+        V8_INCLUDE_DIR=$i/include/v8
+        V8_LIBRARY_DIR=$i/$PHP_LIBDIR
         AC_MSG_RESULT(found in $i)
       fi
     done
   fi
 
-  AC_DEFINE_UNQUOTED([PHP_V8_EXEC_PATH], "$V8_DIR/$SEARCH_FOR", [Full path to libv8 library file])
+  AC_DEFINE_UNQUOTED([PHP_V8_EXEC_PATH], "$V8_LIBRARY_DIR/$SEARCH_FOR", [Full path to libv8 library file])
 
-  if test -z "$V8_DIR"; then
+  if test -z "$V8_INCLUDE_DIR" || test -z "$V8_LIBRARY_DIR"; then
     AC_MSG_RESULT([not found])
     AC_MSG_ERROR([Please reinstall the v8 distribution])
   fi
 
-  PHP_ADD_INCLUDE($V8_DIR/include)
-  PHP_ADD_LIBRARY_WITH_PATH(v8, $V8_DIR/$PHP_LIBDIR, V8JS_SHARED_LIBADD)
+  PHP_ADD_INCLUDE($V8_INCLUDE_DIR)
+  PHP_ADD_LIBRARY_WITH_PATH(v8, $V8_LIBRARY_DIR, V8JS_SHARED_LIBADD)
   PHP_SUBST(V8JS_SHARED_LIBADD)
   PHP_REQUIRE_CXX()
 
@@ -89,8 +91,8 @@ if test "$PHP_V8JS" != "no"; then
 
   AC_LANG_PUSH([C++])
 
-  CPPFLAGS="$CPPFLAGS -I$V8_DIR/include -std=$ac_cv_v8_cstd"
-  LDFLAGS="$LDFLAGS -L$V8_DIR/$PHP_LIBDIR"
+  CPPFLAGS="$CPPFLAGS -I$V8_INCLUDE_DIR -std=$ac_cv_v8_cstd"
+  LDFLAGS="$LDFLAGS -L$V8_LIBRARY_DIR"
 
   AC_MSG_CHECKING([for libv8_libplatform])
   AC_DEFUN([V8_CHECK_LINK], [
@@ -161,7 +163,7 @@ int main ()
 	AC_MSG_CHECKING([for $1])
 	blob_found=0
 
-	for i in "$V8_DIR/$PHP_LIBDIR" "$V8_DIR/share/v8"; do
+	for i in "$V8_LIBRARY_DIR" "$V8_INCLUDE_DIR/../share/v8"; do
 	  if test -r "$i/$1"; then
 		AC_MSG_RESULT([found ($i/$1)])
 		AC_DEFINE_UNQUOTED([$2], "$i/$1", [Full path to $1 file])
@@ -219,7 +221,7 @@ int main ()
 
   AC_DEFINE([V8_DEPRECATION_WARNINGS], [1], [Enable compiler warnings when using V8_DEPRECATED apis.])
 
-  PHP_ADD_INCLUDE($V8_DIR)
+  PHP_ADD_INCLUDE($V8_INCLUDE_DIR)
   PHP_NEW_EXTENSION(v8js, [	\
     v8js_array_access.cc	\
     v8js_class.cc			\


### PR DESCRIPTION
Solves #522
Solves #529

This pull request shall allow debian/ubuntu installation to get this extension running quickly. I tested it using this script and empty OS installations:

```bash
apt update -yy && apt install -y build-essential git libv8-dev php php-dev
git clone https://github.com/JoshuaBehrens/v8js.git --branch feature/hassle-free-installation
cd v8js
phpize
./configure
make 
make test
make install
php -dextension=v8js -m
```

I tested this on Debian 12 on amd64 and arm64 Hetzner VMs with no further sources. So I was running php@8.2 and v8@10. Debian 11 provides php@7.4 out of the box and only ships v8@7 and does not run out of the box. Likely works with different php and v8 sources.

I tried it on CentOS 9 Stream on arm64 but there is a really bad support for arm binaries. I tried also on an amd64 machine and it is an installation hell. The v8-devel package depends on nodejs@16. There is a yum module for nodejs but only for nodejs 18, 20 and 22. AFAIK 18 would've be the matching one to v8@10 but v8-devel seems to be for the headers and library. Yikes!
I compiled v8 following your instructions in the Linux Readme. This is really helpful and sort of works. Eventually I got it running there but it is not handy on the first try:
```bash
yum install git php php-devel unzip curl
curl -L https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip -o ninja-linux.zip
unzip ninja-linux.zip
export PATH=`pwd`:$PATH

git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
export PATH=`pwd`/depot_tools:"$PATH"
fetch v8
cd v8
git checkout 10.2.154.26
gclient sync

tools/dev/v8gen.py -vv x64.release -- is_component_build=true use_custom_libcxx=false
ninja -C out.gn/x64.release/

sudo mkdir -p /opt/v8/{lib,include}
sudo cp out.gn/x64.release/lib*.so out.gn/x64.release/*_blob.bin   out.gn/x64.release/icudtl.dat /opt/v8/lib/
sudo cp -R include/* /opt/v8/include/

cd $HOME

git clone https://github.com/JoshuaBehrens/v8js.git --branch feature/hassle-free-installation
cd v8js
phpize
./configure --with-v8js=/opt/v8/ CPPFLAGS="-DV8_COMPRESS_POINTERS"
make
make test
make install
php -dextension=v8js -m
```

I tried it on alpine but this seems to be a hassle-some story seeing Dockerfiles like this: https://github.com/modprobe/alpine-v8/blob/master/Dockerfile that need an interim debian layer for things to work.

I tried it on macOS 14/SDK 15 and installed v8 via homebrew but this is shipping v8 in version 12. This code is not yet ready for v8@12. I fixed some parts but this is a rabbit hole I am not yet ready to dig through. But I have a change for the config.m4, that understands to work with the filestructure in /opt/homebrew. So it might be a good additional change later, when I got v8@10 on macOS running.

So I tried to build a homebrew formula to build an old version of v8 as there was once a v8 formula compiling version 10 but it collides with the macOS SDK headers and the ones, that llvm ships. Really dumb one. I will try to work that one out because it is a shame, that there is only a "latest" formula. And I really need the macOS support.