### PR TITLE
PHP 8.4

### DIFF
--- a/tests/commonjs_exception_001.phpt
+++ b/tests/commonjs_exception_001.phpt
@@ -20,13 +20,13 @@ $v8->executeString($JS, 'module.js', V8Js::FLAG_PROPAGATE_PHP_EXCEPTIONS);
 --EXPECTF--
 Fatal error: Uncaught Exception: some exception in %s%ecommonjs_exception_001.php:9
 Stack trace:
-#0 [internal function]: {closure}('test')
+#0 [internal function]: {closur%s}('test')
 #1 %s%ecommonjs_exception_001.php(12): V8Js->executeString('var foo = requi...', 'module.js', 4)
 #2 {main}
 
 Next V8JsScriptException: module.js:1: Exception: some exception in %s%ecommonjs_exception_001.php:9
 Stack trace:
-#0 [internal function]: {closure}('test')
+#0 [internal function]: {closur%s}('test')
 #1 %s%ecommonjs_exception_001.php(12): V8Js->executeString('var foo = requi...', 'module.js', 4)
 #2 {main} in %s%ecommonjs_exception_001.php:12
 Stack trace:

--- a/tests/commonjs_exception_002.phpt
+++ b/tests/commonjs_exception_002.phpt
@@ -23,13 +23,13 @@ $v8->executeString($JS, 'module.js', V8Js::FLAG_PROPAGATE_PHP_EXCEPTIONS);
 --EXPECTF--
 Fatal error: Uncaught Exception: some exception in %s%ecommonjs_exception_002.php:9
 Stack trace:
-#0 [internal function]: {closure}('', './test')
+#0 [internal function]: {closur%s}('', './test')
 #1 %s%ecommonjs_exception_002.php(15): V8Js->executeString('var foo = requi...', 'module.js', 4)
 #2 {main}
 
 Next V8JsScriptException: module.js:1: Exception: some exception in %s%ecommonjs_exception_002.php:9
 Stack trace:
-#0 [internal function]: {closure}('', './test')
+#0 [internal function]: {closur%s}('', './test')
 #1 %s%ecommonjs_exception_002.php(15): V8Js->executeString('var foo = requi...', 'module.js', 4)
 #2 {main} in %s%ecommonjs_exception_002.php:15
 Stack trace:

--- a/tests/commonjs_fatal_error.phpt
+++ b/tests/commonjs_fatal_error.phpt
@@ -7,7 +7,7 @@ Test V8Js::setModuleLoader : Handle fatal errors gracefully
 $v8 = new V8Js();
 
 $v8->setModuleLoader(function() {
-    trigger_error('some fatal error', E_USER_ERROR);
+    @trigger_error('some fatal error', E_USER_ERROR);
 });
 
 $v8->executeString(' require("foo"); ');

--- a/tests/fatal_error_no_uninstall_inner_frame.phpt
+++ b/tests/fatal_error_no_uninstall_inner_frame.phpt
@@ -29,7 +29,7 @@ nothing.
 
 Fatal error: Uncaught Error: Call to a member function foo() on null in %s%efatal_error_no_uninstall_inner_frame.php:15
 Stack trace:
-#0 [internal function]: {closure}()
+#0 [internal function]: {closur%s}()
 #1 [internal function]: Closure->__invoke()
 #2 %s%efatal_error_no_uninstall_inner_frame.php(18): V8Js->executeString('PHP.foo();')
 #3 {main}

--- a/tests/fatal_error_recursive.phpt
+++ b/tests/fatal_error_recursive.phpt
@@ -37,13 +37,13 @@ foo
 
 Fatal error: Uncaught Error: Call to a member function bar() on null in %s%efatal_error_recursive.php:7
 Stack trace:
-#0 [internal function]: {closure}()
+#0 [internal function]: {closur%s}()
 #1 [internal function]: Closure->__invoke()
 #2 %s%efatal_error_recursive.php(12): V8Js->executeString('PHP.baz();')
-#3 [internal function]: {closure}()
+#3 [internal function]: {closur%s}()
 #4 [internal function]: Closure->__invoke()
 #5 %s%efatal_error_recursive.php(17): V8Js->executeString('PHP.bar();')
-#6 [internal function]: {closure}()
+#6 [internal function]: {closur%s}()
 #7 [internal function]: Closure->__invoke()
 #8 %s%efatal_error_recursive.php(25): V8Js->executeString('PHP.nofail(); P...')
 #9 {main}

--- a/tests/fatal_error_rethrow.phpt
+++ b/tests/fatal_error_rethrow.phpt
@@ -25,7 +25,7 @@ $js->executeString($script);
 --EXPECTF--
 Fatal error: Uncaught Error: Call to a member function bar() on %s in %s%efatal_error_rethrow.php:7
 Stack trace:
-#0 [internal function]: {closure}()
+#0 [internal function]: {closur%s}()
 #1 [internal function]: Closure->__invoke()
 #2 %s%efatal_error_rethrow.php(16): V8Js->executeString(%s)
 #3 {main}

--- a/tests/generators_from_v8_008.phpt
+++ b/tests/generators_from_v8_008.phpt
@@ -37,7 +37,7 @@ int(23)
 
 Fatal error: Uncaught Exception: this shall not work in %s
 Stack trace:
-#0 [internal function]: {closure}()
+#0 [internal function]: {closur%s}()
 #1 [internal function]: Closure->__invoke()
 #2 %s: V8Generator->next()
 #3 {main}

--- a/tests/generators_from_v8_009.phpt
+++ b/tests/generators_from_v8_009.phpt
@@ -22,7 +22,7 @@ EOJS;
 
 $v8 = new V8Js();
 $v8->getValue = function() {
-    trigger_error("you're gonna fail now", E_USER_ERROR);
+    @trigger_error("you're gonna fail now", E_USER_ERROR);
 };
 $gen = $v8->executeString($js);
 

--- a/tests/var_dump.phpt
+++ b/tests/var_dump.phpt
@@ -1,7 +1,10 @@
 --TEST--
 Test V8::executeString() : var_dump
 --SKIPIF--
-<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+<?php
+require_once(dirname(__FILE__) . '/skipif.inc');
+if (PHP_VERSION_ID < 80400) die('skip Only for php version >= 8.4');
+?>
 --INI--
 date.timezone=UTC
 --FILE--
@@ -70,254 +73,266 @@ try {
 }
 ?>
 ===EOF===
---EXPECTREGEX--
-\-\-\-\- PHP var_dump of PHP object \-\-\-\-
-array\(11\) \{
-  \["null"\]\=\>
+--EXPECTF--
+---- PHP var_dump of PHP object ----
+array(11) {
+  ["null"]=>
   NULL
-  \["bool"\]\=\>
-  bool\(true\)
-  \["string"\]\=\>
-  string\(6\) "string"
-  \["uint"\]\=\>
-  int\(1\)
-  \["int"\]\=\>
-  int\(\-1\)
-  \["number"\]\=\>
-  float\(3\.141592654\)
-  \["date"\]\=\>
-  object\(DateTime\)\#\d+ \(3\) \{
-    \["date"\]\=\>
-    string\(\d+\) "1976\-09\-27 09\:00\:00((\.0+)?)"
-    \["timezone_type"\]\=\>
-    int\(3\)
-    \["timezone"\]\=\>
-    string\(3\) "UTC"
-  \}
-  \["array"\]\=\>
-  array\(3\) \{
-    \[0\]\=\>
-    int\(1\)
-    \[1\]\=\>
-    int\(2\)
-    \[2\]\=\>
-    int\(3\)
-  \}
-  \["object"\]\=\>
-  array\(1\) \{
-    \["field"\]\=\>
-    string\(3\) "foo"
-  \}
-  \["function"\]\=\>
-  object\(Closure\)\#\d+ \(1\) \{
-    \["parameter"\]\=\>
-    array\(1\) \{
-      \["\$x"\]\=\>
-      string\(10\) "\<required\>"
-    \}
-  \}
-  \["phpobject"\]\=\>
-  object\(Foo\)\#\d+ \(1\) \{
-    \["field"\]\=\>
-    string\(3\) "php"
-  \}
-\}
-\-\-\- JS var_dump of PHP object \-\-\-\-
-array \(11\) \{
-  \["null"\] \=\>
+  ["bool"]=>
+  bool(true)
+  ["string"]=>
+  string(6) "string"
+  ["uint"]=>
+  int(1)
+  ["int"]=>
+  int(-1)
+  ["number"]=>
+  float(3.141592654)
+  ["date"]=>
+  object(DateTime)#3 (3) {
+    ["date"]=>
+    string(26) "1976-09-27 09:00:00.000000"
+    ["timezone_type"]=>
+    int(3)
+    ["timezone"]=>
+    string(3) "UTC"
+  }
+  ["array"]=>
+  array(3) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(2)
+    [2]=>
+    int(3)
+  }
+  ["object"]=>
+  array(1) {
+    ["field"]=>
+    string(3) "foo"
+  }
+  ["function"]=>
+  object(Closure)#4 (4) {
+    ["name"]=>
+    string(45) "{closure:/tmp/php-v8js/tests/var_dump.php:51}"
+    ["file"]=>
+    string(32) "/tmp/php-v8js/tests/var_dump.php"
+    ["line"]=>
+    int(51)
+    ["parameter"]=>
+    array(1) {
+      ["$x"]=>
+      string(10) "<required>"
+    }
+  }
+  ["phpobject"]=>
+  object(Foo)#5 (1) {
+    ["field"]=>
+    string(3) "php"
+  }
+}
+--- JS var_dump of PHP object ----
+array (11) {
+  ["null"] =>
   NULL
-  \["bool"\] \=\>
-  bool\(true\)
-  \["string"\] \=\>
-  string\(6\) "string"
-  \["uint"\] \=\>
-  int\(1\)
-  \["int"\] \=\>
-  int\(\-1\)
-  \["number"\] \=\>
-  float\(3\.141593\)
-  \["date"\] \=\>
-  object\(DateTime\)\#\d+ \(\d+\) \{(?:
-    \["createFromImmutable"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \})?(?:
-    \["createFromInterface"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \})?
-    \["createFromFormat"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["getLastErrors"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["format"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["modify"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["add"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["sub"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["getTimezone"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["setTimezone"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["getOffset"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["setTime"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["setDate"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["setISODate"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["setTimestamp"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["getTimestamp"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}
-    \["diff"\] \=\>
-    object\(Closure\)\#\d+ \{
-        function \(\) \{ \[native code\] \}
-    \}(?:(?:the following block is missing from PHP 7.4 on){0}
-    \["\$date"\] \=\>
-    string\(\d+\) "1976\-09\-27 09\:00\:00((\.0+)?)"
-    \["\$timezone_type"\] \=\>
-    int\(3\)
-    \["\$timezone"\] \=\>
-    string\(3\) "UTC"
- )?\s*\}
-  \["array"\] \=\>
-  array\(3\) \{
-    \[0\] \=\>
-    int\(1\)
-    \[1\] \=\>
-    int\(2\)
-    \[2\] \=\>
-    int\(3\)
-  \}
-  \["object"\] \=\>
-  array \(1\) \{
-    \["field"\] \=\>
-    string\(3\) "foo"
-  \}
-  \["function"\] \=\>
-  object\(Closure\)\#\d+ \(0\) \{
-  \}
-  \["phpobject"\] \=\>
-  object\(Foo\)\#\d+ \(1\) \{
-    \["\$field"\] \=\>
-    string\(3\) "php"
-  \}
-\}
-\-\-\- JS var_dump of JS object \-\-\-\-
-object\(Object\)\#\d+ \(12\) \{
-  \["undefined"\] \=\>
+  ["bool"] =>
+  bool(true)
+  ["string"] =>
+  string(6) "string"
+  ["uint"] =>
+  int(1)
+  ["int"] =>
+  int(-1)
+  ["number"] =>
+  float(3.141593)
+  ["date"] =>
+  object(DateTime)#%d (20) {
+    ["createFromImmutable"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["createFromInterface"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["createFromFormat"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["createFromTimestamp"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["getLastErrors"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["format"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["modify"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["add"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["sub"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["getTimezone"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["setTimezone"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["getOffset"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["getMicrosecond"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["setTime"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["setDate"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["setISODate"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["setTimestamp"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["setMicrosecond"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["getTimestamp"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+    ["diff"] =>
+    object(Closure)#%d {
+        function () { [native code] }
+    }
+  }
+  ["array"] =>
+  array(3) {
+    [0] =>
+    int(1)
+    [1] =>
+    int(2)
+    [2] =>
+    int(3)
+  }
+  ["object"] =>
+  array (1) {
+    ["field"] =>
+    string(3) "foo"
+  }
+  ["function"] =>
+  object(Closure)#%d (0) {
+  }
+  ["phpobject"] =>
+  object(Foo)#%d (1) {
+    ["$field"] =>
+    string(3) "php"
+  }
+}
+--- JS var_dump of JS object ----
+object(Object)#%d (12) {
+  ["undefined"] =>
   NULL
-  \["null"\] \=\>
+  ["null"] =>
   NULL
-  \["bool"\] \=\>
-  bool\(true\)
-  \["string"\] \=\>
-  string\(6\) "string"
-  \["uint"\] \=\>
-  int\(1\)
-  \["int"\] \=\>
-  int\(\-1\)
-  \["number"\] \=\>
-  float\(3\.141593\)
-  \["regexp"\] \=\>
-  regexp\(\/regexp\/\)
-  \["array"\] \=\>
-  array\(3\) \{
-    \[0\] \=\>
-    int\(1\)
-    \[1\] \=\>
-    int\(2\)
-    \[2\] \=\>
-    int\(3\)
-  \}
-  \["object"\] \=\>
-  object\(Object\)\#\d+ \(1\) \{
-    \["field"\] \=\>
-    string\(3\) "foo"
-  \}
-  \["function"\] \=\>
-  object\(Closure\)\#\d+ \{
-      function id\(x\) \{ return x; \}
-  \}
-  \["phpobject"\] \=\>
-  object\(Foo\)\#\d+ \(1\) \{
-    \["\$field"\] \=\>
-    string\(3\) "php"
-  \}
-\}
-\-\-\- PHP var_dump of JS object \-\-\-\-
-object\(V8Object\)\#\d+ \(12\) \{
-  \["undefined"\]\=\>
+  ["bool"] =>
+  bool(true)
+  ["string"] =>
+  string(6) "string"
+  ["uint"] =>
+  int(1)
+  ["int"] =>
+  int(-1)
+  ["number"] =>
+  float(3.141593)
+  ["regexp"] =>
+  regexp(/regexp/)
+  ["array"] =>
+  array(3) {
+    [0] =>
+    int(1)
+    [1] =>
+    int(2)
+    [2] =>
+    int(3)
+  }
+  ["object"] =>
+  object(Object)#%d (1) {
+    ["field"] =>
+    string(3) "foo"
+  }
+  ["function"] =>
+  object(Closure)#%d {
+      function id(x) { return x; }
+  }
+  ["phpobject"] =>
+  object(Foo)#%d (1) {
+    ["$field"] =>
+    string(3) "php"
+  }
+}
+--- PHP var_dump of JS object ----
+object(V8Object)#6 (12) {
+  ["undefined"]=>
   NULL
-  \["null"\]\=\>
+  ["null"]=>
   NULL
-  \["bool"\]\=\>
-  bool\(true\)
-  \["string"\]\=\>
-  string\(6\) "string"
-  \["uint"\]\=\>
-  int\(1\)
-  \["int"\]\=\>
-  int\(\-1\)
-  \["number"\]\=\>
-  float\(3\.141592654\)
-  \["regexp"\]\=\>
-  object\(V8Object\)\#\d+ \(0\) \{
-  \}
-  \["array"\]\=\>
-  array\(3\) \{
-    \[0\]\=\>
-    int\(1\)
-    \[1\]\=\>
-    int\(2\)
-    \[2\]\=\>
-    int\(3\)
-  \}
-  \["object"\]\=\>
-  object\(V8Object\)\#\d+ \(1\) \{
-    \["field"\]\=\>
-    string\(3\) "foo"
-  \}
-  \["function"\]\=\>
-  object\(V8Function\)\#\d+ \(0\) \{
-  \}
-  \["phpobject"\]\=\>
-  object\(Foo\)\#\d+ \(1\) \{
-    \["field"\]\=\>
-    string\(3\) "php"
-  \}
-\}
-\=\=\=EOF\=\=\=
+  ["bool"]=>
+  bool(true)
+  ["string"]=>
+  string(6) "string"
+  ["uint"]=>
+  int(1)
+  ["int"]=>
+  int(-1)
+  ["number"]=>
+  float(3.141592654)
+  ["regexp"]=>
+  object(V8Object)#7 (0) {
+  }
+  ["array"]=>
+  array(3) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(2)
+    [2]=>
+    int(3)
+  }
+  ["object"]=>
+  object(V8Object)#8 (1) {
+    ["field"]=>
+    string(3) "foo"
+  }
+  ["function"]=>
+  object(V8Function)#9 (0) {
+  }
+  ["phpobject"]=>
+  object(Foo)#2 (1) {
+    ["field"]=>
+    string(3) "php"
+  }
+}
+===EOF===

--- a/tests/var_dump_php83.phpt
+++ b/tests/var_dump_php83.phpt
@@ -1,0 +1,326 @@
+--TEST--
+Test V8::executeString() : var_dump
+--SKIPIF--
+<?php
+require_once(dirname(__FILE__) . '/skipif.inc');
+if (PHP_VERSION_ID >= 80400) die('skip Only for php version < 8.4');
+?>
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+# Test var_dump of various types
+
+$JS = <<< EOT
+
+print("--- JS var_dump of PHP object ----\\n");
+var_dump(PHP.phptypes);
+
+print("--- JS var_dump of JS object ----\\n");
+var types = {
+	undefined: undefined,
+	null: null,
+	bool: true,
+	string: "string",
+	uint: 1,
+	int: -1,
+	number: 3.141592654,
+	// XXX this gets parsed with local timezone,
+	//     which is bad for test repeatability.
+	//date: new Date('September 27, 1976 09:00:00 GMT'),
+	regexp: /regexp/,
+	array: [1,2,3],
+	object: { field: "foo" },
+	function: function id(x) { return x; },
+	phpobject: PHP.obj
+};
+
+var_dump(types);
+print("--- PHP var_dump of JS object ----\\n");
+types;
+EOT;
+
+class Foo {
+	  var $field = "php";
+}
+
+$v8 = new V8Js();
+$v8->obj = new Foo;
+
+$phptypes = $v8->phptypes = array(
+	"null" => NULL,
+	"bool" => true,
+	"string" => "string",
+	"uint" => 1,
+	"int" => -1,
+	"number" => 3.141592654,
+	"date" => new DateTime('September 27, 1976 09:00:00 UTC', new DateTimeZone('UTC')),
+	//"regexp" => new Regexp('/regexp/'), /* no native PHP regex type */
+	"array" => array(1,2,3),
+	"object" => array( "field" => "foo" ),
+	"function" => (function ($x) { return $x; }),
+	"phpobject" => new Foo
+);
+
+echo "---- PHP var_dump of PHP object ----\n";
+var_dump($phptypes);
+
+try {
+	var_dump($v8->executeString($JS, 'var_dump.js'));
+} catch (V8JsScriptException $e) {
+	echo "Error!\n";
+	var_dump($e);
+}
+?>
+===EOF===
+--EXPECTREGEX--
+\-\-\-\- PHP var_dump of PHP object \-\-\-\-
+array\(11\) \{
+  \["null"\]\=\>
+  NULL
+  \["bool"\]\=\>
+  bool\(true\)
+  \["string"\]\=\>
+  string\(6\) "string"
+  \["uint"\]\=\>
+  int\(1\)
+  \["int"\]\=\>
+  int\(\-1\)
+  \["number"\]\=\>
+  float\(3\.141592654\)
+  \["date"\]\=\>
+  object\(DateTime\)\#\d+ \(3\) \{
+    \["date"\]\=\>
+    string\(\d+\) "1976\-09\-27 09\:00\:00((\.0+)?)"
+    \["timezone_type"\]\=\>
+    int\(3\)
+    \["timezone"\]\=\>
+    string\(3\) "UTC"
+  \}
+  \["array"\]\=\>
+  array\(3\) \{
+    \[0\]\=\>
+    int\(1\)
+    \[1\]\=\>
+    int\(2\)
+    \[2\]\=\>
+    int\(3\)
+  \}
+  \["object"\]\=\>
+  array\(1\) \{
+    \["field"\]\=\>
+    string\(3\) "foo"
+  \}
+  \["function"\]\=\>
+  object\(Closure\)\#\d+ \(1\) \{
+    \["parameter"\]\=\>
+    array\(1\) \{
+      \["\$x"\]\=\>
+      string\(10\) "\<required\>"
+    \}
+  \}
+  \["phpobject"\]\=\>
+  object\(Foo\)\#\d+ \(1\) \{
+    \["field"\]\=\>
+    string\(3\) "php"
+  \}
+\}
+\-\-\- JS var_dump of PHP object \-\-\-\-
+array \(11\) \{
+  \["null"\] \=\>
+  NULL
+  \["bool"\] \=\>
+  bool\(true\)
+  \["string"\] \=\>
+  string\(6\) "string"
+  \["uint"\] \=\>
+  int\(1\)
+  \["int"\] \=\>
+  int\(\-1\)
+  \["number"\] \=\>
+  float\(3\.141593\)
+  \["date"\] \=\>
+  object\(DateTime\)\#\d+ \(\d+\) \{(?:
+    \["createFromImmutable"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \})?(?:
+    \["createFromInterface"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \})?
+    \["createFromFormat"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["getLastErrors"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["format"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["modify"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["add"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["sub"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["getTimezone"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["setTimezone"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["getOffset"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["setTime"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["setDate"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["setISODate"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["setTimestamp"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["getTimestamp"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}
+    \["diff"\] \=\>
+    object\(Closure\)\#\d+ \{
+        function \(\) \{ \[native code\] \}
+    \}(?:(?:the following block is missing from PHP 7.4 on){0}
+    \["\$date"\] \=\>
+    string\(\d+\) "1976\-09\-27 09\:00\:00((\.0+)?)"
+    \["\$timezone_type"\] \=\>
+    int\(3\)
+    \["\$timezone"\] \=\>
+    string\(3\) "UTC"
+ )?\s*\}
+  \["array"\] \=\>
+  array\(3\) \{
+    \[0\] \=\>
+    int\(1\)
+    \[1\] \=\>
+    int\(2\)
+    \[2\] \=\>
+    int\(3\)
+  \}
+  \["object"\] \=\>
+  array \(1\) \{
+    \["field"\] \=\>
+    string\(3\) "foo"
+  \}
+  \["function"\] \=\>
+  object\(Closure\)\#\d+ \(0\) \{
+  \}
+  \["phpobject"\] \=\>
+  object\(Foo\)\#\d+ \(1\) \{
+    \["\$field"\] \=\>
+    string\(3\) "php"
+  \}
+\}
+\-\-\- JS var_dump of JS object \-\-\-\-
+object\(Object\)\#\d+ \(12\) \{
+  \["undefined"\] \=\>
+  NULL
+  \["null"\] \=\>
+  NULL
+  \["bool"\] \=\>
+  bool\(true\)
+  \["string"\] \=\>
+  string\(6\) "string"
+  \["uint"\] \=\>
+  int\(1\)
+  \["int"\] \=\>
+  int\(\-1\)
+  \["number"\] \=\>
+  float\(3\.141593\)
+  \["regexp"\] \=\>
+  regexp\(\/regexp\/\)
+  \["array"\] \=\>
+  array\(3\) \{
+    \[0\] \=\>
+    int\(1\)
+    \[1\] \=\>
+    int\(2\)
+    \[2\] \=\>
+    int\(3\)
+  \}
+  \["object"\] \=\>
+  object\(Object\)\#\d+ \(1\) \{
+    \["field"\] \=\>
+    string\(3\) "foo"
+  \}
+  \["function"\] \=\>
+  object\(Closure\)\#\d+ \{
+      function id\(x\) \{ return x; \}
+  \}
+  \["phpobject"\] \=\>
+  object\(Foo\)\#\d+ \(1\) \{
+    \["\$field"\] \=\>
+    string\(3\) "php"
+  \}
+\}
+\-\-\- PHP var_dump of JS object \-\-\-\-
+object\(V8Object\)\#\d+ \(12\) \{
+  \["undefined"\]\=\>
+  NULL
+  \["null"\]\=\>
+  NULL
+  \["bool"\]\=\>
+  bool\(true\)
+  \["string"\]\=\>
+  string\(6\) "string"
+  \["uint"\]\=\>
+  int\(1\)
+  \["int"\]\=\>
+  int\(\-1\)
+  \["number"\]\=\>
+  float\(3\.141592654\)
+  \["regexp"\]\=\>
+  object\(V8Object\)\#\d+ \(0\) \{
+  \}
+  \["array"\]\=\>
+  array\(3\) \{
+    \[0\]\=\>
+    int\(1\)
+    \[1\]\=\>
+    int\(2\)
+    \[2\]\=\>
+    int\(3\)
+  \}
+  \["object"\]\=\>
+  object\(V8Object\)\#\d+ \(1\) \{
+    \["field"\]\=\>
+    string\(3\) "foo"
+  \}
+  \["function"\]\=\>
+  object\(V8Function\)\#\d+ \(0\) \{
+  \}
+  \["phpobject"\]\=\>
+  object\(Foo\)\#\d+ \(1\) \{
+    \["field"\]\=\>
+    string\(3\) "php"
+  \}
+\}
+\=\=\=EOF\=\=\=

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -675,7 +675,7 @@ v8::Local<v8::Value> v8js_named_property_callback(v8::Isolate *isolate, v8::Loca
 	ce = scope = object->ce;
 
 	/* First, check the (case-insensitive) method table */
-	php_strtolower(lower, name_len);
+	zend_str_tolower(lower, name_len);
 	method_name = zend_string_init(lower, name_len, 0);
 
 	// toString() -> __tostring()


### PR DESCRIPTION
## PHP 8.4

**TLDR: 179/180 (+2 skip) tests passed (99.4%)**

<details>
<summary>php 8.4.2 (on x86_64) test report:</summary>

```
=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Test V8::executeString() : Time limit [tests/time_limit.phpt]
=====================================================================


=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :     0
Exts tested     :    32
---------------------------------------------------------------------

Number of tests :   182               180
Tests skipped   :     2 (  1.1%) --------
Tests warned    :     0 (  0.0%) (  0.0%)
Tests failed    :     1 (  0.5%) (  0.6%)
Tests passed    :   179 ( 98.4%) ( 99.4%)
---------------------------------------------------------------------
Time taken      : 10.312 seconds
=====================================================================

=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Test V8::executeString() : Time limit [tests/time_limit.phpt]
=====================================================================


================================================================================
/tmp/php-v8js/tests/time_limit.phpt
================================================================================
NULL
===EOF===
================================================================================
001- V8JsTimeLimitException
002- Script time limit of 1000 milliseconds exceeded
001+ NULL
     ===EOF===

================================================================================




================================================================================
BUILD ENVIRONMENT
================================================================================
OS:
Linux - Linux buildkitsandbox 6.12.8-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 02 Jan 2025 22:52:26 +0000 x86_64

Autoconf:
autoconf (GNU Autoconf) 2.71
Copyright (C) 2021 Free Software Foundation, Inc.
License GPLv3+/Autoconf: GNU GPL version 3 or later
<https://gnu.org/licenses/gpl.html>, <https://gnu.org/licenses/exceptions.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by David J. MacKenzie and Akim Demaille.

Bundled Libtool:
ltmain.sh (GNU libtool) 1.5.26 (1.1220.2.492 2008/01/30 06:40:56)

Copyright (C) 2008  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

System Libtool:
N/A
Compiler:
Using built-in specs.
COLLECT_GCC=cc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/12/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none:amdgcn-amdhsa
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Debian 12.2.0-14' --with-bugurl=file:///usr/share/doc/gcc-12/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-12 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --disable-werror --enable-cet --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none=/build/gcc-12-bTRWOB/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/gcc-12-bTRWOB/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-offload-defaulted --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.2.0 (Debian 12.2.0-14) 

Bison:

Libraries:
	linux-vdso.so.1 (0x0000720a5a506000)
	libreadline.so.8 => /lib/x86_64-linux-gnu/libreadline.so.8 (0x0000720a5a4a5000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x0000720a58b21000)
	libxml2.so.2 => /lib/x86_64-linux-gnu/libxml2.so.2 (0x0000720a58975000)
	libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x0000720a588cc000)
	libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x0000720a58446000)
	libsqlite3.so.0 => /lib/x86_64-linux-gnu/libsqlite3.so.0 (0x0000720a582e7000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x0000720a5a484000)
	libcurl.so.4 => /lib/x86_64-linux-gnu/libcurl.so.4 (0x0000720a58238000)
	libonig.so.5 => /lib/x86_64-linux-gnu/libonig.so.5 (0x0000720a581a1000)
	libargon2.so.1 => /lib/x86_64-linux-gnu/libargon2.so.1 (0x0000720a5a47a000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000720a57fc0000)
	libtinfo.so.6 => /lib/x86_64-linux-gnu/libtinfo.so.6 (0x0000720a5a445000)
	/lib64/ld-linux-x86-64.so.2 (0x0000720a5a508000)
	libicuuc.so.72 => /lib/x86_64-linux-gnu/libicuuc.so.72 (0x0000720a57dc2000)
	liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x0000720a57d93000)
	libnghttp2.so.14 => /lib/x86_64-linux-gnu/libnghttp2.so.14 (0x0000720a57d64000)
	libidn2.so.0 => /lib/x86_64-linux-gnu/libidn2.so.0 (0x0000720a57d33000)
	librtmp.so.1 => /lib/x86_64-linux-gnu/librtmp.so.1 (0x0000720a57d14000)
	libssh2.so.1 => /lib/x86_64-linux-gnu/libssh2.so.1 (0x0000720a57cd3000)
	libpsl.so.5 => /lib/x86_64-linux-gnu/libpsl.so.5 (0x0000720a5a42f000)
	libgssapi_krb5.so.2 => /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 (0x0000720a57c80000)
	libldap-2.5.so.0 => /lib/x86_64-linux-gnu/libldap-2.5.so.0 (0x0000720a57c21000)
	liblber-2.5.so.0 => /lib/x86_64-linux-gnu/liblber-2.5.so.0 (0x0000720a57c11000)
	libzstd.so.1 => /lib/x86_64-linux-gnu/libzstd.so.1 (0x0000720a57b55000)
	libbrotlidec.so.1 => /lib/x86_64-linux-gnu/libbrotlidec.so.1 (0x0000720a57b48000)
	libicudata.so.72 => /lib/x86_64-linux-gnu/libicudata.so.72 (0x0000720a55d76000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x0000720a55b5c000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x0000720a55b3c000)
	libunistring.so.2 => /lib/x86_64-linux-gnu/libunistring.so.2 (0x0000720a55986000)
	libgnutls.so.30 => /lib/x86_64-linux-gnu/libgnutls.so.30 (0x0000720a5576a000)
	libhogweed.so.6 => /lib/x86_64-linux-gnu/libhogweed.so.6 (0x0000720a55721000)
	libnettle.so.8 => /lib/x86_64-linux-gnu/libnettle.so.8 (0x0000720a556d3000)
	libgmp.so.10 => /lib/x86_64-linux-gnu/libgmp.so.10 (0x0000720a55652000)
	libkrb5.so.3 => /lib/x86_64-linux-gnu/libkrb5.so.3 (0x0000720a55576000)
	libk5crypto.so.3 => /lib/x86_64-linux-gnu/libk5crypto.so.3 (0x0000720a55549000)
	libcom_err.so.2 => /lib/x86_64-linux-gnu/libcom_err.so.2 (0x0000720a55543000)
	libkrb5support.so.0 => /lib/x86_64-linux-gnu/libkrb5support.so.0 (0x0000720a55535000)
	libsasl2.so.2 => /lib/x86_64-linux-gnu/libsasl2.so.2 (0x0000720a55518000)
	libbrotlicommon.so.1 => /lib/x86_64-linux-gnu/libbrotlicommon.so.1 (0x0000720a554f3000)
	libp11-kit.so.0 => /lib/x86_64-linux-gnu/libp11-kit.so.0 (0x0000720a553bf000)
	libtasn1.so.6 => /lib/x86_64-linux-gnu/libtasn1.so.6 (0x0000720a553aa000)
	libkeyutils.so.1 => /lib/x86_64-linux-gnu/libkeyutils.so.1 (0x0000720a553a3000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x0000720a55392000)
	libffi.so.8 => /lib/x86_64-linux-gnu/libffi.so.8 (0x0000720a55384000)



================================================================================
PHPINFO
================================================================================
phpinfo()
PHP Version => 8.4.2

System => Linux buildkitsandbox 6.12.8-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 02 Jan 2025 22:52:26 +0000 x86_64
Build Date => Dec 24 2024 22:21:04
Build System => Linux - Docker
Build Provider => https://github.com/docker-library/php
Configure Command =>  './configure'  '--build=x86_64-linux-gnu' '--with-config-file-path=/usr/local/etc/php' '--with-config-file-scan-dir=/usr/local/etc/php/conf.d' '--enable-option-checking=fatal' '--with-mhash' '--with-pic' '--enable-mbstring' '--enable-mysqlnd' '--with-password-argon2' '--with-sodium=shared' '--with-pdo-sqlite=/usr' '--with-sqlite3=/usr' '--with-curl' '--with-iconv' '--with-openssl' '--with-readline' '--with-zlib' '--enable-phpdbg' '--enable-phpdbg-readline' '--with-pear' '--with-libdir=lib/x86_64-linux-gnu' '--enable-embed' 'build_alias=x86_64-linux-gnu' 'PHP_UNAME=Linux - Docker' 'PHP_BUILD_PROVIDER=https://github.com/docker-library/php'
Server API => Command Line Interface
Virtual Directory Support => disabled
Configuration File (php.ini) Path => /usr/local/etc/php
Loaded Configuration File => (none)
Scan this dir for additional .ini files => /usr/local/etc/php/conf.d
Additional .ini files parsed => /usr/local/etc/php/conf.d/docker-php-ext-sodium.ini

PHP API => 20240924
PHP Extension => 20240924
Zend Extension => 420240924
Zend Extension Build => API420240924,NTS
PHP Extension Build => API20240924,NTS
PHP Integer Size => 64 bits
Debug Build => no
Thread Safety => disabled
Zend Signal Handling => enabled
Zend Memory Manager => enabled
Zend Multibyte Support => provided by mbstring
Zend Max Execution Timers => disabled
IPv6 Support => enabled
DTrace Support => disabled

Registered PHP Streams => https, ftps, compress.zlib, php, file, glob, data, http, ftp, phar
Registered Stream Socket Transports => tcp, udp, unix, udg, ssl, tls, tlsv1.0, tlsv1.1, tlsv1.2, tlsv1.3
Registered Stream Filters => zlib.*, convert.iconv.*, string.rot13, string.toupper, string.tolower, convert.*, consumed, dechunk

This program makes use of the Zend Scripting Language Engine:
Zend Engine v4.4.2, Copyright (c) Zend Technologies


 _______________________________________________________________________


Configuration

Core

PHP Version => 8.4.2

Directive => Local Value => Master Value
allow_url_fopen => On => On
allow_url_include => Off => Off
arg_separator.input => & => &
arg_separator.output => & => &
auto_append_file => no value => no value
auto_globals_jit => On => On
auto_prepend_file => no value => no value
browscap => no value => no value
default_charset => UTF-8 => UTF-8
default_mimetype => text/html => text/html
disable_classes => no value => no value
disable_functions => no value => no value
display_errors => STDERR => STDERR
display_startup_errors => On => On
doc_root => no value => no value
docref_ext => no value => no value
docref_root => no value => no value
enable_dl => On => On
enable_post_data_reading => On => On
error_append_string => no value => no value
error_log => no value => no value
error_log_mode => 0644 => 0644
error_prepend_string => no value => no value
error_reporting => no value => no value
expose_php => On => On
extension_dir => /usr/local/lib/php/extensions/no-debug-non-zts-20240924 => /usr/local/lib/php/extensions/no-debug-non-zts-20240924
fiber.stack_size => no value => no value
file_uploads => On => On
hard_timeout => 2 => 2
highlight.comment => <span style="color: #FF8000">#FF8000</span> => <span style="color: #FF8000">#FF8000</span>
highlight.default => <span style="color: #0000BB">#0000BB</span> => <span style="color: #0000BB">#0000BB</span>
highlight.html => <span style="color: #000000">#000000</span> => <span style="color: #000000">#000000</span>
highlight.keyword => <span style="color: #007700">#007700</span> => <span style="color: #007700">#007700</span>
highlight.string => <span style="color: #DD0000">#DD0000</span> => <span style="color: #DD0000">#DD0000</span>
html_errors => Off => Off
ignore_repeated_errors => Off => Off
ignore_repeated_source => Off => Off
ignore_user_abort => Off => Off
implicit_flush => On => On
include_path => .:/usr/local/lib/php => .:/usr/local/lib/php
input_encoding => no value => no value
internal_encoding => no value => no value
log_errors => Off => Off
mail.add_x_header => Off => Off
mail.force_extra_parameters => no value => no value
mail.log => no value => no value
mail.mixed_lf_and_crlf => Off => Off
max_execution_time => 0 => 0
max_file_uploads => 20 => 20
max_input_nesting_level => 64 => 64
max_input_time => -1 => -1
max_input_vars => 1000 => 1000
max_multipart_body_parts => -1 => -1
memory_limit => 128M => 128M
open_basedir => no value => no value
output_buffering => 0 => 0
output_encoding => no value => no value
output_handler => no value => no value
post_max_size => 8M => 8M
precision => 14 => 14
realpath_cache_size => 4096K => 4096K
realpath_cache_ttl => 120 => 120
register_argc_argv => On => On
report_memleaks => On => On
report_zend_debug => Off => Off
request_order => no value => no value
sendmail_from => no value => no value
sendmail_path => /usr/sbin/sendmail -t -i => /usr/sbin/sendmail -t -i
serialize_precision => -1 => -1
short_open_tag => On => On
SMTP => localhost => localhost
smtp_port => 25 => 25
sys_temp_dir => no value => no value
syslog.facility => LOG_USER => LOG_USER
syslog.filter => no-ctrl => no-ctrl
syslog.ident => php => php
unserialize_callback_func => no value => no value
upload_max_filesize => 2M => 2M
upload_tmp_dir => no value => no value
user_dir => no value => no value
user_ini.cache_ttl => 300 => 300
user_ini.filename => .user.ini => .user.ini
variables_order => EGPCS => EGPCS
xmlrpc_error_number => 0 => 0
xmlrpc_errors => Off => Off
zend.assertions => 1 => 1
zend.detect_unicode => On => On
zend.enable_gc => On => On
zend.exception_ignore_args => Off => Off
zend.exception_string_param_max_len => 15 => 15
zend.max_allowed_stack_size => 0 => 0
zend.multibyte => Off => Off
zend.reserved_stack_size => 0 => 0
zend.script_encoding => no value => no value
zend.signal_check => Off => Off

ctype

ctype functions => enabled

curl

cURL support => enabled
cURL Information => 7.88.1
Age => 10
Features
AsynchDNS => Yes
CharConv => No
Debug => No
GSS-Negotiate => No
IDN => Yes
IPv6 => Yes
krb4 => No
Largefile => Yes
libz => Yes
NTLM => Yes
NTLMWB => Yes
SPNEGO => Yes
SSL => Yes
SSPI => No
TLS-SRP => Yes
HTTP2 => Yes
GSSAPI => Yes
KERBEROS5 => Yes
UNIX_SOCKETS => Yes
PSL => Yes
HTTPS_PROXY => Yes
MULTI_SSL => No
BROTLI => Yes
ALTSVC => Yes
HTTP3 => No
UNICODE => No
ZSTD => Yes
HSTS => Yes
GSASL => No
Protocols => dict, file, ftp, ftps, gopher, gophers, http, https, imap, imaps, ldap, ldaps, mqtt, pop3, pop3s, rtmp, rtmpe, rtmps, rtmpt, rtmpte, rtmpts, rtsp, scp, sftp, smb, smbs, smtp, smtps, telnet, tftp
Host => x86_64-pc-linux-gnu
SSL Version => OpenSSL/3.0.15
ZLib Version => 1.2.13
libSSH Version => libssh2/1.10.0

Directive => Local Value => Master Value
curl.cainfo => no value => no value

date

date/time support => enabled
timelib version => 2022.12
"Olson" Timezone Database Version => 2024.2
Timezone Database => internal
Default timezone => UTC

Directive => Local Value => Master Value
date.default_latitude => 31.7667 => 31.7667
date.default_longitude => 35.2333 => 35.2333
date.sunrise_zenith => 90.833333 => 90.833333
date.sunset_zenith => 90.833333 => 90.833333
date.timezone => UTC => UTC

dom

DOM/XML => enabled
DOM/XML API Version => 20031129
libxml Version => 2.9.14
HTML Support => enabled
XPath Support => enabled
XPointer Support => enabled
Schema Support => enabled
RelaxNG Support => enabled

fileinfo

fileinfo support => enabled
libmagic => 545

filter

Input Validation and Filtering => enabled

Directive => Local Value => Master Value
filter.default => unsafe_raw => unsafe_raw
filter.default_flags => no value => no value

hash

hash support => enabled
Hashing Engines => md2 md4 md5 sha1 sha224 sha256 sha384 sha512/224 sha512/256 sha512 sha3-224 sha3-256 sha3-384 sha3-512 ripemd128 ripemd160 ripemd256 ripemd320 whirlpool tiger128,3 tiger160,3 tiger192,3 tiger128,4 tiger160,4 tiger192,4 snefru snefru256 gost gost-crypto adler32 crc32 crc32b crc32c fnv132 fnv1a32 fnv164 fnv1a64 joaat murmur3a murmur3c murmur3f xxh32 xxh64 xxh3 xxh128 haval128,3 haval160,3 haval192,3 haval224,3 haval256,3 haval128,4 haval160,4 haval192,4 haval224,4 haval256,4 haval128,5 haval160,5 haval192,5 haval224,5 haval256,5 

MHASH support => Enabled
MHASH API Version => Emulated Support

iconv

iconv support => enabled
iconv implementation => glibc
iconv library version => 2.36

Directive => Local Value => Master Value
iconv.input_encoding => no value => no value
iconv.internal_encoding => no value => no value
iconv.output_encoding => no value => no value

json

json support => enabled

libxml

libXML support => active
libXML Compiled Version => 2.9.14
libXML Loaded Version => 20914
libXML streams => enabled

mbstring

Multibyte Support => enabled
Multibyte string engine => libmbfl
HTTP input encoding translation => disabled
libmbfl version => 1.3.2

mbstring extension makes use of "streamable kanji code filter and converter", which is distributed under the GNU Lesser General Public License version 2.1.

Multibyte (japanese) regex support => enabled
Multibyte regex (oniguruma) version => 6.9.8

Directive => Local Value => Master Value
mbstring.detect_order => no value => no value
mbstring.encoding_translation => Off => Off
mbstring.http_input => no value => no value
mbstring.http_output => no value => no value
mbstring.http_output_conv_mimetypes => ^(text/|application/xhtml\+xml) => ^(text/|application/xhtml\+xml)
mbstring.internal_encoding => no value => no value
mbstring.language => neutral => neutral
mbstring.regex_retry_limit => 1000000 => 1000000
mbstring.regex_stack_limit => 100000 => 100000
mbstring.strict_detection => Off => Off
mbstring.substitute_character => no value => no value

mysqlnd

mysqlnd => enabled
Version => mysqlnd 8.4.2
Compression => supported
core SSL => supported
extended SSL => supported
Command buffer size => 4096
Read buffer size => 32768
Read timeout => 86400
Collecting statistics => Yes
Collecting memory statistics => No
Tracing => n/a
Loaded plugins => mysqlnd,debug_trace,auth_plugin_mysql_native_password,auth_plugin_mysql_clear_password,auth_plugin_caching_sha2_password,auth_plugin_sha256_password
API Extensions =>  

openssl

OpenSSL support => enabled
OpenSSL Library Version => OpenSSL 3.0.15 3 Sep 2024
OpenSSL Header Version => OpenSSL 3.0.15 3 Sep 2024
Openssl default config => /usr/lib/ssl/openssl.cnf

Directive => Local Value => Master Value
openssl.cafile => no value => no value
openssl.capath => no value => no value

pcre

PCRE (Perl Compatible Regular Expressions) Support => enabled
PCRE Library Version => 10.44 2024-06-07
PCRE Unicode Version => 15.0.0
PCRE JIT Support => enabled
PCRE JIT Target => x86 64bit (little endian + unaligned)

Directive => Local Value => Master Value
pcre.backtrack_limit => 1000000 => 1000000
pcre.jit => On => On
pcre.recursion_limit => 100000 => 100000

PDO

PDO support => enabled
PDO drivers => sqlite

pdo_sqlite

PDO Driver for SQLite 3.x => enabled
SQLite Library => 3.40.1

Phar

Phar: PHP Archive support => enabled
Phar API version => 1.1.1
Phar-based phar archives => enabled
Tar-based phar archives => enabled
ZIP-based phar archives => enabled
gzip compression => enabled
bzip2 compression => disabled (install ext/bz2)
Native OpenSSL support => enabled


Phar based on pear/PHP_Archive, original concept by Davey Shafik.
Phar fully realized by Gregory Beaver and Marcus Boerger.
Portions of tar implementation Copyright (c) 2003-2009 Tim Kientzle.
Directive => Local Value => Master Value
phar.cache_list => no value => no value
phar.readonly => On => On
phar.require_hash => On => On

posix

POSIX support => enabled

random

Version => 8.4.2

readline

Readline Support => enabled
Readline library => 8.2

Directive => Local Value => Master Value
cli.pager => no value => no value
cli.prompt => \b \>  => \b \> 

Reflection

Reflection => enabled

session

Session Support => enabled
Registered save handlers => files user 
Registered serializer handlers => php_serialize php php_binary 

Directive => Local Value => Master Value
session.auto_start => Off => Off
session.cache_expire => 180 => 180
session.cache_limiter => nocache => nocache
session.cookie_domain => no value => no value
session.cookie_httponly => Off => Off
session.cookie_lifetime => 0 => 0
session.cookie_path => / => /
session.cookie_samesite => no value => no value
session.cookie_secure => Off => Off
session.gc_divisor => 100 => 100
session.gc_maxlifetime => 1440 => 1440
session.gc_probability => 1 => 1
session.lazy_write => On => On
session.name => PHPSESSID => PHPSESSID
session.referer_check => no value => no value
session.save_handler => files => files
session.save_path => no value => no value
session.serialize_handler => php => php
session.sid_bits_per_character => 4 => 4
session.sid_length => 32 => 32
session.upload_progress.cleanup => On => On
session.upload_progress.enabled => On => On
session.upload_progress.freq => 1% => 1%
session.upload_progress.min_freq => 1 => 1
session.upload_progress.name => PHP_SESSION_UPLOAD_PROGRESS => PHP_SESSION_UPLOAD_PROGRESS
session.upload_progress.prefix => upload_progress_ => upload_progress_
session.use_cookies => On => On
session.use_only_cookies => On => On
session.use_strict_mode => Off => Off
session.use_trans_sid => Off => Off

SimpleXML

SimpleXML support => enabled
Schema support => enabled

sodium

sodium support => enabled
libsodium headers version => 1.0.18
libsodium library version => 1.0.18

SPL

SPL support => enabled
Interfaces => OuterIterator, RecursiveIterator, SeekableIterator, SplObserver, SplSubject
Classes => AppendIterator, ArrayIterator, ArrayObject, BadFunctionCallException, BadMethodCallException, CachingIterator, CallbackFilterIterator, DirectoryIterator, DomainException, EmptyIterator, FilesystemIterator, FilterIterator, GlobIterator, InfiniteIterator, InvalidArgumentException, IteratorIterator, LengthException, LimitIterator, LogicException, MultipleIterator, NoRewindIterator, OutOfBoundsException, OutOfRangeException, OverflowException, ParentIterator, RangeException, RecursiveArrayIterator, RecursiveCachingIterator, RecursiveCallbackFilterIterator, RecursiveDirectoryIterator, RecursiveFilterIterator, RecursiveIteratorIterator, RecursiveRegexIterator, RecursiveTreeIterator, RegexIterator, RuntimeException, SplDoublyLinkedList, SplFileInfo, SplFileObject, SplFixedArray, SplHeap, SplMinHeap, SplMaxHeap, SplObjectStorage, SplPriorityQueue, SplQueue, SplStack, SplTempFileObject, UnderflowException, UnexpectedValueException

sqlite3

SQLite3 support => enabled
SQLite Library => 3.40.1

Directive => Local Value => Master Value
sqlite3.defensive => On => On
sqlite3.extension_dir => no value => no value

standard

Dynamic Library Support => enabled
Path to sendmail => /usr/sbin/sendmail -t -i

Directive => Local Value => Master Value
assert.active => On => On
assert.bail => Off => Off
assert.callback => no value => no value
assert.exception => On => On
assert.warning => On => On
auto_detect_line_endings => Off => Off
default_socket_timeout => 60 => 60
from => no value => no value
session.trans_sid_hosts => no value => no value
session.trans_sid_tags => a=href,area=href,frame=src,form= => a=href,area=href,frame=src,form=
unserialize_max_depth => 4096 => 4096
url_rewriter.hosts => no value => no value
url_rewriter.tags => form= => form=
user_agent => no value => no value

tokenizer

Tokenizer Support => enabled

xml

XML Support => active
XML Namespace Support => active
libxml2 Version => 2.9.14

xmlreader

XMLReader => enabled

xmlwriter

XMLWriter => enabled

zlib

ZLib Support => enabled
Stream Wrapper => compress.zlib://
Stream Filter => zlib.inflate, zlib.deflate
Compiled Version => 1.2.13
Linked Version => 1.2.13

Directive => Local Value => Master Value
zlib.output_compression => Off => Off
zlib.output_compression_level => -1 => -1
zlib.output_handler => no value => no value

Additional Modules

Module Name

Environment

Variable => Value
SSH_CLIENT => deleted
PHP_INI_DIR => /usr/local/etc/php
SHLVL => 1
TEST_PHP_SRCDIR => /tmp/php-v8js
HOME => /root
SSH_TTY => deleted
PHP_LDFLAGS => -Wl,-O1 -pie
TEST_PHP_CGI_EXECUTABLE => /usr/local/bin/php-cgi
MAKEFLAGS =>  
PHP_CFLAGS => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
PHP_VERSION => 8.4.2
GPG_KEYS => AFD8691FDAEDF03BDF6E460563F15A9B715376CA 9D7F99A0CB8F05C8A6958D6256A97AF7600A39A6 0616E93D95AF471243E26761770426E17EBBB3DD
PHP_ASC_URL => https://www.php.net/distributions/php-8.4.2.tar.xz.asc
PHP_CPPFLAGS => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
TEST_PHP_EXECUTABLE => /usr/local/bin/php
_ => /usr/local/bin/php
PHP_URL => https://www.php.net/distributions/php-8.4.2.tar.xz
PATH => /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
TEST_PHP_CGI_EXECUTABLE_ESCAPED => '/usr/local/bin/php-cgi'
MAKELEVEL => 1
PREFIX => php8.4.2_x86_64__
SSH_AUTH_SOCK => deleted
TEST_PHPDBG_EXECUTABLE => /usr/local/bin/phpdbg
TEST_PHP_EXECUTABLE_ESCAPED => '/usr/local/bin/php'
PWD => /tmp/php-v8js
PHPIZE_DEPS => autoconf 		dpkg-dev 		file 		g++ 		gcc 		libc-dev 		make 		pkg-config 		re2c
PHP_SHA256 => 92636453210f7f2174d6ee6df17a5811368f556a6c2c2cbcf019321e36456e01
SSH_CONNECTION => deleted
CC => cc
MFLAGS =>  
TEST_PHPDBG_EXECUTABLE_ESCAPED => '/usr/local/bin/phpdbg'

PHP Variables

Variable => Value
$_SERVER['SSH_CLIENT'] => deleted
$_SERVER['PHP_INI_DIR'] => /usr/local/etc/php
$_SERVER['SHLVL'] => 1
$_SERVER['TEST_PHP_SRCDIR'] => /tmp/php-v8js
$_SERVER['HOME'] => /root
$_SERVER['SSH_TTY'] => deleted
$_SERVER['PHP_LDFLAGS'] => -Wl,-O1 -pie
$_SERVER['TEST_PHP_CGI_EXECUTABLE'] => /usr/local/bin/php-cgi
$_SERVER['MAKEFLAGS'] => 
$_SERVER['PHP_CFLAGS'] => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
$_SERVER['PHP_VERSION'] => 8.4.2
$_SERVER['GPG_KEYS'] => AFD8691FDAEDF03BDF6E460563F15A9B715376CA 9D7F99A0CB8F05C8A6958D6256A97AF7600A39A6 0616E93D95AF471243E26761770426E17EBBB3DD
$_SERVER['PHP_ASC_URL'] => https://www.php.net/distributions/php-8.4.2.tar.xz.asc
$_SERVER['PHP_CPPFLAGS'] => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
$_SERVER['TEST_PHP_EXECUTABLE'] => /usr/local/bin/php
$_SERVER['_'] => /usr/local/bin/php
$_SERVER['PHP_URL'] => https://www.php.net/distributions/php-8.4.2.tar.xz
$_SERVER['PATH'] => /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
$_SERVER['TEST_PHP_CGI_EXECUTABLE_ESCAPED'] => '/usr/local/bin/php-cgi'
$_SERVER['MAKELEVEL'] => 1
$_SERVER['PREFIX'] => php8.4.2_x86_64__
$_SERVER['SSH_AUTH_SOCK'] => deleted
$_SERVER['TEST_PHPDBG_EXECUTABLE'] => /usr/local/bin/phpdbg
$_SERVER['TEST_PHP_EXECUTABLE_ESCAPED'] => '/usr/local/bin/php'
$_SERVER['PWD'] => /tmp/php-v8js
$_SERVER['PHPIZE_DEPS'] => autoconf 		dpkg-dev 		file 		g++ 		gcc 		libc-dev 		make 		pkg-config 		re2c
$_SERVER['PHP_SHA256'] => 92636453210f7f2174d6ee6df17a5811368f556a6c2c2cbcf019321e36456e01
$_SERVER['SSH_CONNECTION'] => deleted
$_SERVER['CC'] => cc
$_SERVER['MFLAGS'] => 
$_SERVER['TEST_PHPDBG_EXECUTABLE_ESCAPED'] => '/usr/local/bin/phpdbg'
$_SERVER['PHP_SELF'] => 
$_SERVER['SCRIPT_NAME'] => 
$_SERVER['SCRIPT_FILENAME'] => 
$_SERVER['PATH_TRANSLATED'] => 
$_SERVER['DOCUMENT_ROOT'] => 
$_SERVER['REQUEST_TIME_FLOAT'] => 1736413966.3523
$_SERVER['REQUEST_TIME'] => 1736413966
$_SERVER['argv'] => Array
(
)

$_SERVER['argc'] => 0
$_ENV['SSH_CLIENT'] => deleted
$_ENV['PHP_INI_DIR'] => /usr/local/etc/php
$_ENV['SHLVL'] => 1
$_ENV['TEST_PHP_SRCDIR'] => /tmp/php-v8js
$_ENV['HOME'] => /root
$_ENV['SSH_TTY'] => deleted
$_ENV['PHP_LDFLAGS'] => -Wl,-O1 -pie
$_ENV['TEST_PHP_CGI_EXECUTABLE'] => /usr/local/bin/php-cgi
$_ENV['MAKEFLAGS'] => 
$_ENV['PHP_CFLAGS'] => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
$_ENV['PHP_VERSION'] => 8.4.2
$_ENV['GPG_KEYS'] => AFD8691FDAEDF03BDF6E460563F15A9B715376CA 9D7F99A0CB8F05C8A6958D6256A97AF7600A39A6 0616E93D95AF471243E26761770426E17EBBB3DD
$_ENV['PHP_ASC_URL'] => https://www.php.net/distributions/php-8.4.2.tar.xz.asc
$_ENV['PHP_CPPFLAGS'] => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
$_ENV['TEST_PHP_EXECUTABLE'] => /usr/local/bin/php
$_ENV['_'] => /usr/local/bin/php
$_ENV['PHP_URL'] => https://www.php.net/distributions/php-8.4.2.tar.xz
$_ENV['PATH'] => /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
$_ENV['TEST_PHP_CGI_EXECUTABLE_ESCAPED'] => '/usr/local/bin/php-cgi'
$_ENV['MAKELEVEL'] => 1
$_ENV['PREFIX'] => php8.4.2_x86_64__
$_ENV['SSH_AUTH_SOCK'] => deleted
$_ENV['TEST_PHPDBG_EXECUTABLE'] => /usr/local/bin/phpdbg
$_ENV['TEST_PHP_EXECUTABLE_ESCAPED'] => '/usr/local/bin/php'
$_ENV['PWD'] => /tmp/php-v8js
$_ENV['PHPIZE_DEPS'] => autoconf 		dpkg-dev 		file 		g++ 		gcc 		libc-dev 		make 		pkg-config 		re2c
$_ENV['PHP_SHA256'] => 92636453210f7f2174d6ee6df17a5811368f556a6c2c2cbcf019321e36456e01
$_ENV['SSH_CONNECTION'] => deleted
$_ENV['CC'] => cc
$_ENV['MFLAGS'] => 
$_ENV['TEST_PHPDBG_EXECUTABLE_ESCAPED'] => '/usr/local/bin/phpdbg'
```

</details>

## PHP 8.3

**TLDR: 179/180 (+2 skip) tests passed (99.4%)**

<details>
<summary>php 8.3.15 (on x86_64) test report:</summary>

```
=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Test V8::executeString() : Time limit [tests/time_limit.phpt]
=====================================================================


=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :     0
Exts tested     :    32
---------------------------------------------------------------------

Number of tests :   182               180
Tests skipped   :     2 (  1.1%) --------
Tests warned    :     0 (  0.0%) (  0.0%)
Tests failed    :     1 (  0.5%) (  0.6%)
Tests passed    :   179 ( 98.4%) ( 99.4%)
---------------------------------------------------------------------
Time taken      :     9 seconds
=====================================================================

=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Test V8::executeString() : Time limit [tests/time_limit.phpt]
=====================================================================


================================================================================
/tmp/php-v8js/tests/time_limit.phpt
================================================================================
NULL
===EOF===
================================================================================
001- V8JsTimeLimitException
002- Script time limit of 1000 milliseconds exceeded
001+ NULL
     ===EOF===

================================================================================




================================================================================
BUILD ENVIRONMENT
================================================================================
OS:
Linux - Linux buildkitsandbox 6.12.8-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 02 Jan 2025 22:52:26 +0000 x86_64

Autoconf:
autoconf (GNU Autoconf) 2.71
Copyright (C) 2021 Free Software Foundation, Inc.
License GPLv3+/Autoconf: GNU GPL version 3 or later
<https://gnu.org/licenses/gpl.html>, <https://gnu.org/licenses/exceptions.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by David J. MacKenzie and Akim Demaille.

Bundled Libtool:
ltmain.sh (GNU libtool) 1.5.26 (1.1220.2.492 2008/01/30 06:40:56)

Copyright (C) 2008  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

System Libtool:
N/A
Compiler:
Using built-in specs.
COLLECT_GCC=cc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/12/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none:amdgcn-amdhsa
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Debian 12.2.0-14' --with-bugurl=file:///usr/share/doc/gcc-12/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-12 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --disable-werror --enable-cet --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none=/build/gcc-12-bTRWOB/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/gcc-12-bTRWOB/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-offload-defaulted --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.2.0 (Debian 12.2.0-14) 

Bison:

Libraries:
	linux-vdso.so.1 (0x00007c7c86aa5000)
	libreadline.so.8 => /lib/x86_64-linux-gnu/libreadline.so.8 (0x00007c7c86a44000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007c7c85321000)
	libxml2.so.2 => /lib/x86_64-linux-gnu/libxml2.so.2 (0x00007c7c85175000)
	libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x00007c7c850cc000)
	libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007c7c84c46000)
	libsqlite3.so.0 => /lib/x86_64-linux-gnu/libsqlite3.so.0 (0x00007c7c84ae7000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007c7c84ac8000)
	libcurl.so.4 => /lib/x86_64-linux-gnu/libcurl.so.4 (0x00007c7c84a19000)
	libonig.so.5 => /lib/x86_64-linux-gnu/libonig.so.5 (0x00007c7c84982000)
	libargon2.so.1 => /lib/x86_64-linux-gnu/libargon2.so.1 (0x00007c7c86a38000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007c7c847a1000)
	libtinfo.so.6 => /lib/x86_64-linux-gnu/libtinfo.so.6 (0x00007c7c8476e000)
	/lib64/ld-linux-x86-64.so.2 (0x00007c7c86aa7000)
	libicuuc.so.72 => /lib/x86_64-linux-gnu/libicuuc.so.72 (0x00007c7c84570000)
	liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x00007c7c84541000)
	libnghttp2.so.14 => /lib/x86_64-linux-gnu/libnghttp2.so.14 (0x00007c7c84512000)
	libidn2.so.0 => /lib/x86_64-linux-gnu/libidn2.so.0 (0x00007c7c844e1000)
	librtmp.so.1 => /lib/x86_64-linux-gnu/librtmp.so.1 (0x00007c7c844c2000)
	libssh2.so.1 => /lib/x86_64-linux-gnu/libssh2.so.1 (0x00007c7c84481000)
	libpsl.so.5 => /lib/x86_64-linux-gnu/libpsl.so.5 (0x00007c7c8446d000)
	libgssapi_krb5.so.2 => /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 (0x00007c7c8441a000)
	libldap-2.5.so.0 => /lib/x86_64-linux-gnu/libldap-2.5.so.0 (0x00007c7c843bb000)
	liblber-2.5.so.0 => /lib/x86_64-linux-gnu/liblber-2.5.so.0 (0x00007c7c843ab000)
	libzstd.so.1 => /lib/x86_64-linux-gnu/libzstd.so.1 (0x00007c7c842ef000)
	libbrotlidec.so.1 => /lib/x86_64-linux-gnu/libbrotlidec.so.1 (0x00007c7c842e2000)
	libicudata.so.72 => /lib/x86_64-linux-gnu/libicudata.so.72 (0x00007c7c82510000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007c7c822f6000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007c7c822d6000)
	libunistring.so.2 => /lib/x86_64-linux-gnu/libunistring.so.2 (0x00007c7c82120000)
	libgnutls.so.30 => /lib/x86_64-linux-gnu/libgnutls.so.30 (0x00007c7c81f04000)
	libhogweed.so.6 => /lib/x86_64-linux-gnu/libhogweed.so.6 (0x00007c7c81ebb000)
	libnettle.so.8 => /lib/x86_64-linux-gnu/libnettle.so.8 (0x00007c7c81e6d000)
	libgmp.so.10 => /lib/x86_64-linux-gnu/libgmp.so.10 (0x00007c7c81dec000)
	libkrb5.so.3 => /lib/x86_64-linux-gnu/libkrb5.so.3 (0x00007c7c81d12000)
	libk5crypto.so.3 => /lib/x86_64-linux-gnu/libk5crypto.so.3 (0x00007c7c81ce5000)
	libcom_err.so.2 => /lib/x86_64-linux-gnu/libcom_err.so.2 (0x00007c7c86a28000)
	libkrb5support.so.0 => /lib/x86_64-linux-gnu/libkrb5support.so.0 (0x00007c7c81cd7000)
	libsasl2.so.2 => /lib/x86_64-linux-gnu/libsasl2.so.2 (0x00007c7c81cba000)
	libbrotlicommon.so.1 => /lib/x86_64-linux-gnu/libbrotlicommon.so.1 (0x00007c7c81c95000)
	libp11-kit.so.0 => /lib/x86_64-linux-gnu/libp11-kit.so.0 (0x00007c7c81b61000)
	libtasn1.so.6 => /lib/x86_64-linux-gnu/libtasn1.so.6 (0x00007c7c81b4c000)
	libkeyutils.so.1 => /lib/x86_64-linux-gnu/libkeyutils.so.1 (0x00007c7c81b45000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007c7c81b34000)
	libffi.so.8 => /lib/x86_64-linux-gnu/libffi.so.8 (0x00007c7c81b26000)



================================================================================
PHPINFO
================================================================================
phpinfo()
PHP Version => 8.3.15

System => Linux buildkitsandbox 6.12.8-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 02 Jan 2025 22:52:26 +0000 x86_64
Build Date => Dec 24 2024 22:21:59
Build System => Linux - Docker
Build Provider => https://github.com/docker-library/php
Configure Command =>  './configure'  '--build=x86_64-linux-gnu' '--with-config-file-path=/usr/local/etc/php' '--with-config-file-scan-dir=/usr/local/etc/php/conf.d' '--enable-option-checking=fatal' '--with-mhash' '--with-pic' '--enable-mbstring' '--enable-mysqlnd' '--with-password-argon2' '--with-sodium=shared' '--with-pdo-sqlite=/usr' '--with-sqlite3=/usr' '--with-curl' '--with-iconv' '--with-openssl' '--with-readline' '--with-zlib' '--enable-phpdbg' '--enable-phpdbg-readline' '--with-pear' '--with-libdir=lib/x86_64-linux-gnu' '--enable-embed' 'build_alias=x86_64-linux-gnu'
Server API => Command Line Interface
Virtual Directory Support => disabled
Configuration File (php.ini) Path => /usr/local/etc/php
Loaded Configuration File => (none)
Scan this dir for additional .ini files => /usr/local/etc/php/conf.d
Additional .ini files parsed => /usr/local/etc/php/conf.d/docker-php-ext-sodium.ini

PHP API => 20230831
PHP Extension => 20230831
Zend Extension => 420230831
Zend Extension Build => API420230831,NTS
PHP Extension Build => API20230831,NTS
Debug Build => no
Thread Safety => disabled
Zend Signal Handling => enabled
Zend Memory Manager => enabled
Zend Multibyte Support => provided by mbstring
Zend Max Execution Timers => disabled
IPv6 Support => enabled
DTrace Support => disabled

Registered PHP Streams => https, ftps, compress.zlib, php, file, glob, data, http, ftp, phar
Registered Stream Socket Transports => tcp, udp, unix, udg, ssl, tls, tlsv1.0, tlsv1.1, tlsv1.2, tlsv1.3
Registered Stream Filters => zlib.*, convert.iconv.*, string.rot13, string.toupper, string.tolower, convert.*, consumed, dechunk

This program makes use of the Zend Scripting Language Engine:
Zend Engine v4.3.15, Copyright (c) Zend Technologies


 _______________________________________________________________________


Configuration

Core

PHP Version => 8.3.15

Directive => Local Value => Master Value
allow_url_fopen => On => On
allow_url_include => Off => Off
arg_separator.input => & => &
arg_separator.output => & => &
auto_append_file => no value => no value
auto_globals_jit => On => On
auto_prepend_file => no value => no value
browscap => no value => no value
default_charset => UTF-8 => UTF-8
default_mimetype => text/html => text/html
disable_classes => no value => no value
disable_functions => no value => no value
display_errors => STDERR => STDERR
display_startup_errors => On => On
doc_root => no value => no value
docref_ext => no value => no value
docref_root => no value => no value
enable_dl => On => On
enable_post_data_reading => On => On
error_append_string => no value => no value
error_log => no value => no value
error_log_mode => 0644 => 0644
error_prepend_string => no value => no value
error_reporting => no value => no value
expose_php => On => On
extension_dir => /usr/local/lib/php/extensions/no-debug-non-zts-20230831 => /usr/local/lib/php/extensions/no-debug-non-zts-20230831
fiber.stack_size => no value => no value
file_uploads => On => On
hard_timeout => 2 => 2
highlight.comment => <font style="color: #FF8000">#FF8000</font> => <font style="color: #FF8000">#FF8000</font>
highlight.default => <font style="color: #0000BB">#0000BB</font> => <font style="color: #0000BB">#0000BB</font>
highlight.html => <font style="color: #000000">#000000</font> => <font style="color: #000000">#000000</font>
highlight.keyword => <font style="color: #007700">#007700</font> => <font style="color: #007700">#007700</font>
highlight.string => <font style="color: #DD0000">#DD0000</font> => <font style="color: #DD0000">#DD0000</font>
html_errors => Off => Off
ignore_repeated_errors => Off => Off
ignore_repeated_source => Off => Off
ignore_user_abort => Off => Off
implicit_flush => On => On
include_path => .:/usr/local/lib/php => .:/usr/local/lib/php
input_encoding => no value => no value
internal_encoding => no value => no value
log_errors => Off => Off
mail.add_x_header => Off => Off
mail.force_extra_parameters => no value => no value
mail.log => no value => no value
mail.mixed_lf_and_crlf => Off => Off
max_execution_time => 0 => 0
max_file_uploads => 20 => 20
max_input_nesting_level => 64 => 64
max_input_time => -1 => -1
max_input_vars => 1000 => 1000
max_multipart_body_parts => -1 => -1
memory_limit => 128M => 128M
open_basedir => no value => no value
output_buffering => 0 => 0
output_encoding => no value => no value
output_handler => no value => no value
post_max_size => 8M => 8M
precision => 14 => 14
realpath_cache_size => 4096K => 4096K
realpath_cache_ttl => 120 => 120
register_argc_argv => On => On
report_memleaks => On => On
report_zend_debug => Off => Off
request_order => no value => no value
sendmail_from => no value => no value
sendmail_path => /usr/sbin/sendmail -t -i => /usr/sbin/sendmail -t -i
serialize_precision => -1 => -1
short_open_tag => On => On
SMTP => localhost => localhost
smtp_port => 25 => 25
sys_temp_dir => no value => no value
syslog.facility => LOG_USER => LOG_USER
syslog.filter => no-ctrl => no-ctrl
syslog.ident => php => php
unserialize_callback_func => no value => no value
upload_max_filesize => 2M => 2M
upload_tmp_dir => no value => no value
user_dir => no value => no value
user_ini.cache_ttl => 300 => 300
user_ini.filename => .user.ini => .user.ini
variables_order => EGPCS => EGPCS
xmlrpc_error_number => 0 => 0
xmlrpc_errors => Off => Off
zend.assertions => 1 => 1
zend.detect_unicode => On => On
zend.enable_gc => On => On
zend.exception_ignore_args => Off => Off
zend.exception_string_param_max_len => 15 => 15
zend.max_allowed_stack_size => 0 => 0
zend.multibyte => Off => Off
zend.reserved_stack_size => 0 => 0
zend.script_encoding => no value => no value
zend.signal_check => Off => Off

ctype

ctype functions => enabled

curl

cURL support => enabled
cURL Information => 7.88.1
Age => 10
Features
AsynchDNS => Yes
CharConv => No
Debug => No
GSS-Negotiate => No
IDN => Yes
IPv6 => Yes
krb4 => No
Largefile => Yes
libz => Yes
NTLM => Yes
NTLMWB => Yes
SPNEGO => Yes
SSL => Yes
SSPI => No
TLS-SRP => Yes
HTTP2 => Yes
GSSAPI => Yes
KERBEROS5 => Yes
UNIX_SOCKETS => Yes
PSL => Yes
HTTPS_PROXY => Yes
MULTI_SSL => No
BROTLI => Yes
ALTSVC => Yes
HTTP3 => No
UNICODE => No
ZSTD => Yes
HSTS => Yes
GSASL => No
Protocols => dict, file, ftp, ftps, gopher, gophers, http, https, imap, imaps, ldap, ldaps, mqtt, pop3, pop3s, rtmp, rtmpe, rtmps, rtmpt, rtmpte, rtmpts, rtsp, scp, sftp, smb, smbs, smtp, smtps, telnet, tftp
Host => x86_64-pc-linux-gnu
SSL Version => OpenSSL/3.0.15
ZLib Version => 1.2.13
libSSH Version => libssh2/1.10.0

Directive => Local Value => Master Value
curl.cainfo => no value => no value

date

date/time support => enabled
timelib version => 2022.12
"Olson" Timezone Database Version => 2024.2
Timezone Database => internal
Default timezone => UTC

Directive => Local Value => Master Value
date.default_latitude => 31.7667 => 31.7667
date.default_longitude => 35.2333 => 35.2333
date.sunrise_zenith => 90.833333 => 90.833333
date.sunset_zenith => 90.833333 => 90.833333
date.timezone => UTC => UTC

dom

DOM/XML => enabled
DOM/XML API Version => 20031129
libxml Version => 2.9.14
HTML Support => enabled
XPath Support => enabled
XPointer Support => enabled
Schema Support => enabled
RelaxNG Support => enabled

fileinfo

fileinfo support => enabled
libmagic => 543

filter

Input Validation and Filtering => enabled

Directive => Local Value => Master Value
filter.default => unsafe_raw => unsafe_raw
filter.default_flags => no value => no value

hash

hash support => enabled
Hashing Engines => md2 md4 md5 sha1 sha224 sha256 sha384 sha512/224 sha512/256 sha512 sha3-224 sha3-256 sha3-384 sha3-512 ripemd128 ripemd160 ripemd256 ripemd320 whirlpool tiger128,3 tiger160,3 tiger192,3 tiger128,4 tiger160,4 tiger192,4 snefru snefru256 gost gost-crypto adler32 crc32 crc32b crc32c fnv132 fnv1a32 fnv164 fnv1a64 joaat murmur3a murmur3c murmur3f xxh32 xxh64 xxh3 xxh128 haval128,3 haval160,3 haval192,3 haval224,3 haval256,3 haval128,4 haval160,4 haval192,4 haval224,4 haval256,4 haval128,5 haval160,5 haval192,5 haval224,5 haval256,5 

MHASH support => Enabled
MHASH API Version => Emulated Support

iconv

iconv support => enabled
iconv implementation => glibc
iconv library version => 2.36

Directive => Local Value => Master Value
iconv.input_encoding => no value => no value
iconv.internal_encoding => no value => no value
iconv.output_encoding => no value => no value

json

json support => enabled

libxml

libXML support => active
libXML Compiled Version => 2.9.14
libXML Loaded Version => 20914
libXML streams => enabled

mbstring

Multibyte Support => enabled
Multibyte string engine => libmbfl
HTTP input encoding translation => disabled
libmbfl version => 1.3.2

mbstring extension makes use of "streamable kanji code filter and converter", which is distributed under the GNU Lesser General Public License version 2.1.

Multibyte (japanese) regex support => enabled
Multibyte regex (oniguruma) version => 6.9.8

Directive => Local Value => Master Value
mbstring.detect_order => no value => no value
mbstring.encoding_translation => Off => Off
mbstring.http_input => no value => no value
mbstring.http_output => no value => no value
mbstring.http_output_conv_mimetypes => ^(text/|application/xhtml\+xml) => ^(text/|application/xhtml\+xml)
mbstring.internal_encoding => no value => no value
mbstring.language => neutral => neutral
mbstring.regex_retry_limit => 1000000 => 1000000
mbstring.regex_stack_limit => 100000 => 100000
mbstring.strict_detection => Off => Off
mbstring.substitute_character => no value => no value

mysqlnd

mysqlnd => enabled
Version => mysqlnd 8.3.15
Compression => supported
core SSL => supported
extended SSL => supported
Command buffer size => 4096
Read buffer size => 32768
Read timeout => 86400
Collecting statistics => Yes
Collecting memory statistics => No
Tracing => n/a
Loaded plugins => mysqlnd,debug_trace,auth_plugin_mysql_native_password,auth_plugin_mysql_clear_password,auth_plugin_caching_sha2_password,auth_plugin_sha256_password
API Extensions =>  

openssl

OpenSSL support => enabled
OpenSSL Library Version => OpenSSL 3.0.15 3 Sep 2024
OpenSSL Header Version => OpenSSL 3.0.15 3 Sep 2024
Openssl default config => /usr/lib/ssl/openssl.cnf

Directive => Local Value => Master Value
openssl.cafile => no value => no value
openssl.capath => no value => no value

pcre

PCRE (Perl Compatible Regular Expressions) Support => enabled
PCRE Library Version => 10.42 2022-12-12
PCRE Unicode Version => 14.0.0
PCRE JIT Support => enabled
PCRE JIT Target => x86 64bit (little endian + unaligned)

Directive => Local Value => Master Value
pcre.backtrack_limit => 1000000 => 1000000
pcre.jit => On => On
pcre.recursion_limit => 100000 => 100000

PDO

PDO support => enabled
PDO drivers => sqlite

pdo_sqlite

PDO Driver for SQLite 3.x => enabled
SQLite Library => 3.40.1

Phar

Phar: PHP Archive support => enabled
Phar API version => 1.1.1
Phar-based phar archives => enabled
Tar-based phar archives => enabled
ZIP-based phar archives => enabled
gzip compression => enabled
bzip2 compression => disabled (install ext/bz2)
Native OpenSSL support => enabled


Phar based on pear/PHP_Archive, original concept by Davey Shafik.
Phar fully realized by Gregory Beaver and Marcus Boerger.
Portions of tar implementation Copyright (c) 2003-2009 Tim Kientzle.
Directive => Local Value => Master Value
phar.cache_list => no value => no value
phar.readonly => On => On
phar.require_hash => On => On

posix

POSIX support => enabled

random

Version => 8.3.15

readline

Readline Support => enabled
Readline library => 8.2

Directive => Local Value => Master Value
cli.pager => no value => no value
cli.prompt => \b \>  => \b \> 

Reflection

Reflection => enabled

session

Session Support => enabled
Registered save handlers => files user 
Registered serializer handlers => php_serialize php php_binary 

Directive => Local Value => Master Value
session.auto_start => Off => Off
session.cache_expire => 180 => 180
session.cache_limiter => nocache => nocache
session.cookie_domain => no value => no value
session.cookie_httponly => Off => Off
session.cookie_lifetime => 0 => 0
session.cookie_path => / => /
session.cookie_samesite => no value => no value
session.cookie_secure => Off => Off
session.gc_divisor => 100 => 100
session.gc_maxlifetime => 1440 => 1440
session.gc_probability => 1 => 1
session.lazy_write => On => On
session.name => PHPSESSID => PHPSESSID
session.referer_check => no value => no value
session.save_handler => files => files
session.save_path => no value => no value
session.serialize_handler => php => php
session.sid_bits_per_character => 4 => 4
session.sid_length => 32 => 32
session.upload_progress.cleanup => On => On
session.upload_progress.enabled => On => On
session.upload_progress.freq => 1% => 1%
session.upload_progress.min_freq => 1 => 1
session.upload_progress.name => PHP_SESSION_UPLOAD_PROGRESS => PHP_SESSION_UPLOAD_PROGRESS
session.upload_progress.prefix => upload_progress_ => upload_progress_
session.use_cookies => On => On
session.use_only_cookies => On => On
session.use_strict_mode => Off => Off
session.use_trans_sid => Off => Off

SimpleXML

SimpleXML support => enabled
Schema support => enabled

sodium

sodium support => enabled
libsodium headers version => 1.0.18
libsodium library version => 1.0.18

SPL

SPL support => enabled
Interfaces => OuterIterator, RecursiveIterator, SeekableIterator, SplObserver, SplSubject
Classes => AppendIterator, ArrayIterator, ArrayObject, BadFunctionCallException, BadMethodCallException, CachingIterator, CallbackFilterIterator, DirectoryIterator, DomainException, EmptyIterator, FilesystemIterator, FilterIterator, GlobIterator, InfiniteIterator, InvalidArgumentException, IteratorIterator, LengthException, LimitIterator, LogicException, MultipleIterator, NoRewindIterator, OutOfBoundsException, OutOfRangeException, OverflowException, ParentIterator, RangeException, RecursiveArrayIterator, RecursiveCachingIterator, RecursiveCallbackFilterIterator, RecursiveDirectoryIterator, RecursiveFilterIterator, RecursiveIteratorIterator, RecursiveRegexIterator, RecursiveTreeIterator, RegexIterator, RuntimeException, SplDoublyLinkedList, SplFileInfo, SplFileObject, SplFixedArray, SplHeap, SplMinHeap, SplMaxHeap, SplObjectStorage, SplPriorityQueue, SplQueue, SplStack, SplTempFileObject, UnderflowException, UnexpectedValueException

sqlite3

SQLite3 support => enabled
SQLite Library => 3.40.1

Directive => Local Value => Master Value
sqlite3.defensive => On => On
sqlite3.extension_dir => no value => no value

standard

Dynamic Library Support => enabled
Path to sendmail => /usr/sbin/sendmail -t -i

Directive => Local Value => Master Value
assert.active => On => On
assert.bail => Off => Off
assert.callback => no value => no value
assert.exception => On => On
assert.warning => On => On
auto_detect_line_endings => Off => Off
default_socket_timeout => 60 => 60
from => no value => no value
session.trans_sid_hosts => no value => no value
session.trans_sid_tags => a=href,area=href,frame=src,form= => a=href,area=href,frame=src,form=
unserialize_max_depth => 4096 => 4096
url_rewriter.hosts => no value => no value
url_rewriter.tags => form= => form=
user_agent => no value => no value

tokenizer

Tokenizer Support => enabled

xml

XML Support => active
XML Namespace Support => active
libxml2 Version => 2.9.14

xmlreader

XMLReader => enabled

xmlwriter

XMLWriter => enabled

zlib

ZLib Support => enabled
Stream Wrapper => compress.zlib://
Stream Filter => zlib.inflate, zlib.deflate
Compiled Version => 1.2.13
Linked Version => 1.2.13

Directive => Local Value => Master Value
zlib.output_compression => Off => Off
zlib.output_compression_level => -1 => -1
zlib.output_handler => no value => no value

Additional Modules

Module Name

Environment

Variable => Value
SSH_CLIENT => deleted
PHP_INI_DIR => /usr/local/etc/php
SHLVL => 1
TEST_PHP_SRCDIR => /tmp/php-v8js
HOME => /root
SSH_TTY => deleted
PHP_LDFLAGS => -Wl,-O1 -pie
TEST_PHP_CGI_EXECUTABLE => /usr/local/bin/php-cgi
MAKEFLAGS =>  
PHP_CFLAGS => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
PHP_VERSION => 8.3.15
GPG_KEYS => 1198C0117593497A5EC5C199286AF1F9897469DC C28D937575603EB4ABB725861C0779DC5C0A9DE4 AFD8691FDAEDF03BDF6E460563F15A9B715376CA
PHP_ASC_URL => https://www.php.net/distributions/php-8.3.15.tar.xz.asc
PHP_CPPFLAGS => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
TEST_PHP_EXECUTABLE => /usr/local/bin/php
_ => /usr/local/bin/php
PHP_URL => https://www.php.net/distributions/php-8.3.15.tar.xz
PATH => /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
TEST_PHP_CGI_EXECUTABLE_ESCAPED => '/usr/local/bin/php-cgi'
MAKELEVEL => 1
PREFIX => php8.3.15_x86_64__
SSH_AUTH_SOCK => deleted
TEST_PHPDBG_EXECUTABLE => /usr/local/bin/phpdbg
TEST_PHP_EXECUTABLE_ESCAPED => '/usr/local/bin/php'
PWD => /tmp/php-v8js
PHPIZE_DEPS => autoconf 		dpkg-dev 		file 		g++ 		gcc 		libc-dev 		make 		pkg-config 		re2c
PHP_SHA256 => 3df5d45637283f759eef8fc3ce03de829ded3e200c3da278936a684955d2f94f
SSH_CONNECTION => deleted
CC => cc
MFLAGS =>  
TEST_PHPDBG_EXECUTABLE_ESCAPED => '/usr/local/bin/phpdbg'

PHP Variables

Variable => Value
$_SERVER['SSH_CLIENT'] => deleted
$_SERVER['PHP_INI_DIR'] => /usr/local/etc/php
$_SERVER['SHLVL'] => 1
$_SERVER['TEST_PHP_SRCDIR'] => /tmp/php-v8js
$_SERVER['HOME'] => /root
$_SERVER['SSH_TTY'] => deleted
$_SERVER['PHP_LDFLAGS'] => -Wl,-O1 -pie
$_SERVER['TEST_PHP_CGI_EXECUTABLE'] => /usr/local/bin/php-cgi
$_SERVER['MAKEFLAGS'] => 
$_SERVER['PHP_CFLAGS'] => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
$_SERVER['PHP_VERSION'] => 8.3.15
$_SERVER['GPG_KEYS'] => 1198C0117593497A5EC5C199286AF1F9897469DC C28D937575603EB4ABB725861C0779DC5C0A9DE4 AFD8691FDAEDF03BDF6E460563F15A9B715376CA
$_SERVER['PHP_ASC_URL'] => https://www.php.net/distributions/php-8.3.15.tar.xz.asc
$_SERVER['PHP_CPPFLAGS'] => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
$_SERVER['TEST_PHP_EXECUTABLE'] => /usr/local/bin/php
$_SERVER['_'] => /usr/local/bin/php
$_SERVER['PHP_URL'] => https://www.php.net/distributions/php-8.3.15.tar.xz
$_SERVER['PATH'] => /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
$_SERVER['TEST_PHP_CGI_EXECUTABLE_ESCAPED'] => '/usr/local/bin/php-cgi'
$_SERVER['MAKELEVEL'] => 1
$_SERVER['PREFIX'] => php8.3.15_x86_64__
$_SERVER['SSH_AUTH_SOCK'] => deleted
$_SERVER['TEST_PHPDBG_EXECUTABLE'] => /usr/local/bin/phpdbg
$_SERVER['TEST_PHP_EXECUTABLE_ESCAPED'] => '/usr/local/bin/php'
$_SERVER['PWD'] => /tmp/php-v8js
$_SERVER['PHPIZE_DEPS'] => autoconf 		dpkg-dev 		file 		g++ 		gcc 		libc-dev 		make 		pkg-config 		re2c
$_SERVER['PHP_SHA256'] => 3df5d45637283f759eef8fc3ce03de829ded3e200c3da278936a684955d2f94f
$_SERVER['SSH_CONNECTION'] => deleted
$_SERVER['CC'] => cc
$_SERVER['MFLAGS'] => 
$_SERVER['TEST_PHPDBG_EXECUTABLE_ESCAPED'] => '/usr/local/bin/phpdbg'
$_SERVER['PHP_SELF'] => 
$_SERVER['SCRIPT_NAME'] => 
$_SERVER['SCRIPT_FILENAME'] => 
$_SERVER['PATH_TRANSLATED'] => 
$_SERVER['DOCUMENT_ROOT'] => 
$_SERVER['REQUEST_TIME_FLOAT'] => 1736413968.7106
$_SERVER['REQUEST_TIME'] => 1736413968
$_SERVER['argv'] => Array
(
)

$_SERVER['argc'] => 0
$_ENV['SSH_CLIENT'] => deleted
$_ENV['PHP_INI_DIR'] => /usr/local/etc/php
$_ENV['SHLVL'] => 1
$_ENV['TEST_PHP_SRCDIR'] => /tmp/php-v8js
$_ENV['HOME'] => /root
$_ENV['SSH_TTY'] => deleted
$_ENV['PHP_LDFLAGS'] => -Wl,-O1 -pie
$_ENV['TEST_PHP_CGI_EXECUTABLE'] => /usr/local/bin/php-cgi
$_ENV['MAKEFLAGS'] => 
$_ENV['PHP_CFLAGS'] => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
$_ENV['PHP_VERSION'] => 8.3.15
$_ENV['GPG_KEYS'] => 1198C0117593497A5EC5C199286AF1F9897469DC C28D937575603EB4ABB725861C0779DC5C0A9DE4 AFD8691FDAEDF03BDF6E460563F15A9B715376CA
$_ENV['PHP_ASC_URL'] => https://www.php.net/distributions/php-8.3.15.tar.xz.asc
$_ENV['PHP_CPPFLAGS'] => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
$_ENV['TEST_PHP_EXECUTABLE'] => /usr/local/bin/php
$_ENV['_'] => /usr/local/bin/php
$_ENV['PHP_URL'] => https://www.php.net/distributions/php-8.3.15.tar.xz
$_ENV['PATH'] => /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
$_ENV['TEST_PHP_CGI_EXECUTABLE_ESCAPED'] => '/usr/local/bin/php-cgi'
$_ENV['MAKELEVEL'] => 1
$_ENV['PREFIX'] => php8.3.15_x86_64__
$_ENV['SSH_AUTH_SOCK'] => deleted
$_ENV['TEST_PHPDBG_EXECUTABLE'] => /usr/local/bin/phpdbg
$_ENV['TEST_PHP_EXECUTABLE_ESCAPED'] => '/usr/local/bin/php'
$_ENV['PWD'] => /tmp/php-v8js
$_ENV['PHPIZE_DEPS'] => autoconf 		dpkg-dev 		file 		g++ 		gcc 		libc-dev 		make 		pkg-config 		re2c
$_ENV['PHP_SHA256'] => 3df5d45637283f759eef8fc3ce03de829ded3e200c3da278936a684955d2f94f
$_ENV['SSH_CONNECTION'] => deleted
$_ENV['CC'] => cc
$_ENV['MFLAGS'] => 
$_ENV['TEST_PHPDBG_EXECUTABLE_ESCAPED'] => '/usr/local/bin/phpdbg'
```

</details>

## PHP 8.2

**TLDR: 179/180 (+2 skip) tests passed (99.4%)**

<details>
<summary>php 8.2.27 (on x86_64) test report:</summary>

```
=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Test V8::executeString() : Time limit [tests/time_limit.phpt]
=====================================================================


=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   33
---------------------------------------------------------------------

Number of tests :  182               180
Tests skipped   :    2 (  1.1%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    1 (  0.5%) (  0.6%)
Tests passed    :  179 ( 98.4%) ( 99.4%)
---------------------------------------------------------------------
Time taken      :    9 seconds
=====================================================================

=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Test V8::executeString() : Time limit [tests/time_limit.phpt]
=====================================================================


================================================================================
/tmp/php-v8js/tests/time_limit.phpt
================================================================================
NULL
===EOF===
================================================================================
001- V8JsTimeLimitException
002- Script time limit of 1000 milliseconds exceeded
001+ NULL
     ===EOF===
================================================================================




================================================================================
BUILD ENVIRONMENT
================================================================================
OS:
Linux - Linux buildkitsandbox 6.12.8-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 02 Jan 2025 22:52:26 +0000 x86_64

Autoconf:
autoconf (GNU Autoconf) 2.71
Copyright (C) 2021 Free Software Foundation, Inc.
License GPLv3+/Autoconf: GNU GPL version 3 or later
<https://gnu.org/licenses/gpl.html>, <https://gnu.org/licenses/exceptions.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by David J. MacKenzie and Akim Demaille.

Bundled Libtool:
ltmain.sh (GNU libtool) 1.5.26 (1.1220.2.492 2008/01/30 06:40:56)

Copyright (C) 2008  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

System Libtool:
N/A
Compiler:
Using built-in specs.
COLLECT_GCC=cc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/12/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none:amdgcn-amdhsa
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Debian 12.2.0-14' --with-bugurl=file:///usr/share/doc/gcc-12/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-12 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --disable-werror --enable-cet --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none=/build/gcc-12-bTRWOB/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/gcc-12-bTRWOB/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-offload-defaulted --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.2.0 (Debian 12.2.0-14) 

Bison:

Libraries:
	linux-vdso.so.1 (0x00007bac89284000)
	libreadline.so.8 => /lib/x86_64-linux-gnu/libreadline.so.8 (0x00007bac87da8000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007bac87cc9000)
	libxml2.so.2 => /lib/x86_64-linux-gnu/libxml2.so.2 (0x00007bac87b1d000)
	libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x00007bac87a74000)
	libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007bac875ee000)
	libsqlite3.so.0 => /lib/x86_64-linux-gnu/libsqlite3.so.0 (0x00007bac8748f000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007bac8925a000)
	libcurl.so.4 => /lib/x86_64-linux-gnu/libcurl.so.4 (0x00007bac873e0000)
	libonig.so.5 => /lib/x86_64-linux-gnu/libonig.so.5 (0x00007bac87349000)
	libargon2.so.1 => /lib/x86_64-linux-gnu/libargon2.so.1 (0x00007bac89250000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007bac87168000)
	libtinfo.so.6 => /lib/x86_64-linux-gnu/libtinfo.so.6 (0x00007bac87135000)
	/lib64/ld-linux-x86-64.so.2 (0x00007bac89286000)
	libicuuc.so.72 => /lib/x86_64-linux-gnu/libicuuc.so.72 (0x00007bac86f37000)
	liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x00007bac86f08000)
	libnghttp2.so.14 => /lib/x86_64-linux-gnu/libnghttp2.so.14 (0x00007bac86ed9000)
	libidn2.so.0 => /lib/x86_64-linux-gnu/libidn2.so.0 (0x00007bac86ea8000)
	librtmp.so.1 => /lib/x86_64-linux-gnu/librtmp.so.1 (0x00007bac8922d000)
	libssh2.so.1 => /lib/x86_64-linux-gnu/libssh2.so.1 (0x00007bac86e67000)
	libpsl.so.5 => /lib/x86_64-linux-gnu/libpsl.so.5 (0x00007bac86e53000)
	libgssapi_krb5.so.2 => /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 (0x00007bac86e00000)
	libldap-2.5.so.0 => /lib/x86_64-linux-gnu/libldap-2.5.so.0 (0x00007bac86da1000)
	liblber-2.5.so.0 => /lib/x86_64-linux-gnu/liblber-2.5.so.0 (0x00007bac86d91000)
	libzstd.so.1 => /lib/x86_64-linux-gnu/libzstd.so.1 (0x00007bac86cd5000)
	libbrotlidec.so.1 => /lib/x86_64-linux-gnu/libbrotlidec.so.1 (0x00007bac86cc8000)
	libicudata.so.72 => /lib/x86_64-linux-gnu/libicudata.so.72 (0x00007bac84ef6000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007bac84cdc000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007bac84cbc000)
	libunistring.so.2 => /lib/x86_64-linux-gnu/libunistring.so.2 (0x00007bac84b06000)
	libgnutls.so.30 => /lib/x86_64-linux-gnu/libgnutls.so.30 (0x00007bac848ea000)
	libhogweed.so.6 => /lib/x86_64-linux-gnu/libhogweed.so.6 (0x00007bac848a1000)
	libnettle.so.8 => /lib/x86_64-linux-gnu/libnettle.so.8 (0x00007bac84853000)
	libgmp.so.10 => /lib/x86_64-linux-gnu/libgmp.so.10 (0x00007bac847d2000)
	libkrb5.so.3 => /lib/x86_64-linux-gnu/libkrb5.so.3 (0x00007bac846f8000)
	libk5crypto.so.3 => /lib/x86_64-linux-gnu/libk5crypto.so.3 (0x00007bac846cb000)
	libcom_err.so.2 => /lib/x86_64-linux-gnu/libcom_err.so.2 (0x00007bac846c5000)
	libkrb5support.so.0 => /lib/x86_64-linux-gnu/libkrb5support.so.0 (0x00007bac846b7000)
	libsasl2.so.2 => /lib/x86_64-linux-gnu/libsasl2.so.2 (0x00007bac8469a000)
	libbrotlicommon.so.1 => /lib/x86_64-linux-gnu/libbrotlicommon.so.1 (0x00007bac84675000)
	libp11-kit.so.0 => /lib/x86_64-linux-gnu/libp11-kit.so.0 (0x00007bac84541000)
	libtasn1.so.6 => /lib/x86_64-linux-gnu/libtasn1.so.6 (0x00007bac8452c000)
	libkeyutils.so.1 => /lib/x86_64-linux-gnu/libkeyutils.so.1 (0x00007bac84525000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007bac84514000)
	libffi.so.8 => /lib/x86_64-linux-gnu/libffi.so.8 (0x00007bac84506000)



================================================================================
PHPINFO
================================================================================
phpinfo()
PHP Version => 8.2.27

System => Linux buildkitsandbox 6.12.8-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 02 Jan 2025 22:52:26 +0000 x86_64
Build Date => Dec 24 2024 22:24:52
Build System => Linux - Docker
Build Provider => https://github.com/docker-library/php
Configure Command =>  './configure'  '--build=x86_64-linux-gnu' '--with-config-file-path=/usr/local/etc/php' '--with-config-file-scan-dir=/usr/local/etc/php/conf.d' '--enable-option-checking=fatal' '--with-mhash' '--with-pic' '--enable-mbstring' '--enable-mysqlnd' '--with-password-argon2' '--with-sodium=shared' '--with-pdo-sqlite=/usr' '--with-sqlite3=/usr' '--with-curl' '--with-iconv' '--with-openssl' '--with-readline' '--with-zlib' '--enable-phpdbg' '--enable-phpdbg-readline' '--with-pear' '--with-libdir=lib/x86_64-linux-gnu' '--enable-embed' 'build_alias=x86_64-linux-gnu'
Server API => Command Line Interface
Virtual Directory Support => disabled
Configuration File (php.ini) Path => /usr/local/etc/php
Loaded Configuration File => (none)
Scan this dir for additional .ini files => /usr/local/etc/php/conf.d
Additional .ini files parsed => /usr/local/etc/php/conf.d/docker-php-ext-sodium.ini

PHP API => 20220829
PHP Extension => 20220829
Zend Extension => 420220829
Zend Extension Build => API420220829,NTS
PHP Extension Build => API20220829,NTS
Debug Build => no
Thread Safety => disabled
Zend Signal Handling => enabled
Zend Memory Manager => enabled
Zend Multibyte Support => provided by mbstring
Zend Max Execution Timers => disabled
IPv6 Support => enabled
DTrace Support => disabled

Registered PHP Streams => https, ftps, compress.zlib, php, file, glob, data, http, ftp, phar
Registered Stream Socket Transports => tcp, udp, unix, udg, ssl, tls, tlsv1.0, tlsv1.1, tlsv1.2, tlsv1.3
Registered Stream Filters => zlib.*, convert.iconv.*, string.rot13, string.toupper, string.tolower, convert.*, consumed, dechunk

This program makes use of the Zend Scripting Language Engine:
Zend Engine v4.2.27, Copyright (c) Zend Technologies


 _______________________________________________________________________


Configuration

Core

PHP Version => 8.2.27

Directive => Local Value => Master Value
allow_url_fopen => On => On
allow_url_include => Off => Off
arg_separator.input => & => &
arg_separator.output => & => &
auto_append_file => no value => no value
auto_globals_jit => On => On
auto_prepend_file => no value => no value
browscap => no value => no value
default_charset => UTF-8 => UTF-8
default_mimetype => text/html => text/html
disable_classes => no value => no value
disable_functions => no value => no value
display_errors => STDERR => STDERR
display_startup_errors => On => On
doc_root => no value => no value
docref_ext => no value => no value
docref_root => no value => no value
enable_dl => On => On
enable_post_data_reading => On => On
error_append_string => no value => no value
error_log => no value => no value
error_log_mode => 0644 => 0644
error_prepend_string => no value => no value
error_reporting => no value => no value
expose_php => On => On
extension_dir => /usr/local/lib/php/extensions/no-debug-non-zts-20220829 => /usr/local/lib/php/extensions/no-debug-non-zts-20220829
fiber.stack_size => no value => no value
file_uploads => On => On
hard_timeout => 2 => 2
highlight.comment => <font style="color: #FF8000">#FF8000</font> => <font style="color: #FF8000">#FF8000</font>
highlight.default => <font style="color: #0000BB">#0000BB</font> => <font style="color: #0000BB">#0000BB</font>
highlight.html => <font style="color: #000000">#000000</font> => <font style="color: #000000">#000000</font>
highlight.keyword => <font style="color: #007700">#007700</font> => <font style="color: #007700">#007700</font>
highlight.string => <font style="color: #DD0000">#DD0000</font> => <font style="color: #DD0000">#DD0000</font>
html_errors => Off => Off
ignore_repeated_errors => Off => Off
ignore_repeated_source => Off => Off
ignore_user_abort => Off => Off
implicit_flush => On => On
include_path => .:/usr/local/lib/php => .:/usr/local/lib/php
input_encoding => no value => no value
internal_encoding => no value => no value
log_errors => Off => Off
mail.add_x_header => Off => Off
mail.force_extra_parameters => no value => no value
mail.log => no value => no value
mail.mixed_lf_and_crlf => Off => Off
max_execution_time => 0 => 0
max_file_uploads => 20 => 20
max_input_nesting_level => 64 => 64
max_input_time => -1 => -1
max_input_vars => 1000 => 1000
max_multipart_body_parts => -1 => -1
memory_limit => 128M => 128M
open_basedir => no value => no value
output_buffering => 0 => 0
output_encoding => no value => no value
output_handler => no value => no value
post_max_size => 8M => 8M
precision => 14 => 14
realpath_cache_size => 4096K => 4096K
realpath_cache_ttl => 120 => 120
register_argc_argv => On => On
report_memleaks => On => On
report_zend_debug => Off => Off
request_order => no value => no value
sendmail_from => no value => no value
sendmail_path => /usr/sbin/sendmail -t -i => /usr/sbin/sendmail -t -i
serialize_precision => -1 => -1
short_open_tag => On => On
SMTP => localhost => localhost
smtp_port => 25 => 25
sys_temp_dir => no value => no value
syslog.facility => LOG_USER => LOG_USER
syslog.filter => no-ctrl => no-ctrl
syslog.ident => php => php
unserialize_callback_func => no value => no value
upload_max_filesize => 2M => 2M
upload_tmp_dir => no value => no value
user_dir => no value => no value
user_ini.cache_ttl => 300 => 300
user_ini.filename => .user.ini => .user.ini
variables_order => EGPCS => EGPCS
xmlrpc_error_number => 0 => 0
xmlrpc_errors => Off => Off
zend.assertions => 1 => 1
zend.detect_unicode => On => On
zend.enable_gc => On => On
zend.exception_ignore_args => Off => Off
zend.exception_string_param_max_len => 15 => 15
zend.multibyte => Off => Off
zend.script_encoding => no value => no value
zend.signal_check => Off => Off

ctype

ctype functions => enabled

curl

cURL support => enabled
cURL Information => 7.88.1
Age => 10
Features
AsynchDNS => Yes
CharConv => No
Debug => No
GSS-Negotiate => No
IDN => Yes
IPv6 => Yes
krb4 => No
Largefile => Yes
libz => Yes
NTLM => Yes
NTLMWB => Yes
SPNEGO => Yes
SSL => Yes
SSPI => No
TLS-SRP => Yes
HTTP2 => Yes
GSSAPI => Yes
KERBEROS5 => Yes
UNIX_SOCKETS => Yes
PSL => Yes
HTTPS_PROXY => Yes
MULTI_SSL => No
BROTLI => Yes
ALTSVC => Yes
HTTP3 => No
UNICODE => No
ZSTD => Yes
HSTS => Yes
GSASL => No
Protocols => dict, file, ftp, ftps, gopher, gophers, http, https, imap, imaps, ldap, ldaps, mqtt, pop3, pop3s, rtmp, rtmpe, rtmps, rtmpt, rtmpte, rtmpts, rtsp, scp, sftp, smb, smbs, smtp, smtps, telnet, tftp
Host => x86_64-pc-linux-gnu
SSL Version => OpenSSL/3.0.15
ZLib Version => 1.2.13
libSSH Version => libssh2/1.10.0

Directive => Local Value => Master Value
curl.cainfo => no value => no value

date

date/time support => enabled
timelib version => 2022.12
"Olson" Timezone Database Version => 2024.2
Timezone Database => internal
Default timezone => UTC

Directive => Local Value => Master Value
date.default_latitude => 31.7667 => 31.7667
date.default_longitude => 35.2333 => 35.2333
date.sunrise_zenith => 90.833333 => 90.833333
date.sunset_zenith => 90.833333 => 90.833333
date.timezone => UTC => UTC

dom

DOM/XML => enabled
DOM/XML API Version => 20031129
libxml Version => 2.9.14
HTML Support => enabled
XPath Support => enabled
XPointer Support => enabled
Schema Support => enabled
RelaxNG Support => enabled

fileinfo

fileinfo support => enabled
libmagic => 540

filter

Input Validation and Filtering => enabled

Directive => Local Value => Master Value
filter.default => unsafe_raw => unsafe_raw
filter.default_flags => no value => no value

hash

hash support => enabled
Hashing Engines => md2 md4 md5 sha1 sha224 sha256 sha384 sha512/224 sha512/256 sha512 sha3-224 sha3-256 sha3-384 sha3-512 ripemd128 ripemd160 ripemd256 ripemd320 whirlpool tiger128,3 tiger160,3 tiger192,3 tiger128,4 tiger160,4 tiger192,4 snefru snefru256 gost gost-crypto adler32 crc32 crc32b crc32c fnv132 fnv1a32 fnv164 fnv1a64 joaat murmur3a murmur3c murmur3f xxh32 xxh64 xxh3 xxh128 haval128,3 haval160,3 haval192,3 haval224,3 haval256,3 haval128,4 haval160,4 haval192,4 haval224,4 haval256,4 haval128,5 haval160,5 haval192,5 haval224,5 haval256,5 

MHASH support => Enabled
MHASH API Version => Emulated Support

iconv

iconv support => enabled
iconv implementation => glibc
iconv library version => 2.36

Directive => Local Value => Master Value
iconv.input_encoding => no value => no value
iconv.internal_encoding => no value => no value
iconv.output_encoding => no value => no value

json

json support => enabled

libxml

libXML support => active
libXML Compiled Version => 2.9.14
libXML Loaded Version => 20914
libXML streams => enabled

mbstring

Multibyte Support => enabled
Multibyte string engine => libmbfl
HTTP input encoding translation => disabled
libmbfl version => 1.3.2

mbstring extension makes use of "streamable kanji code filter and converter", which is distributed under the GNU Lesser General Public License version 2.1.

Multibyte (japanese) regex support => enabled
Multibyte regex (oniguruma) version => 6.9.8

Directive => Local Value => Master Value
mbstring.detect_order => no value => no value
mbstring.encoding_translation => Off => Off
mbstring.http_input => no value => no value
mbstring.http_output => no value => no value
mbstring.http_output_conv_mimetypes => ^(text/|application/xhtml\+xml) => ^(text/|application/xhtml\+xml)
mbstring.internal_encoding => no value => no value
mbstring.language => neutral => neutral
mbstring.regex_retry_limit => 1000000 => 1000000
mbstring.regex_stack_limit => 100000 => 100000
mbstring.strict_detection => Off => Off
mbstring.substitute_character => no value => no value

mysqlnd

mysqlnd => enabled
Version => mysqlnd 8.2.27
Compression => supported
core SSL => supported
extended SSL => supported
Command buffer size => 4096
Read buffer size => 32768
Read timeout => 86400
Collecting statistics => Yes
Collecting memory statistics => No
Tracing => n/a
Loaded plugins => mysqlnd,debug_trace,auth_plugin_mysql_native_password,auth_plugin_mysql_clear_password,auth_plugin_caching_sha2_password,auth_plugin_sha256_password
API Extensions =>  

openssl

OpenSSL support => enabled
OpenSSL Library Version => OpenSSL 3.0.15 3 Sep 2024
OpenSSL Header Version => OpenSSL 3.0.15 3 Sep 2024
Openssl default config => /usr/lib/ssl/openssl.cnf

Directive => Local Value => Master Value
openssl.cafile => no value => no value
openssl.capath => no value => no value

pcre

PCRE (Perl Compatible Regular Expressions) Support => enabled
PCRE Library Version => 10.40 2022-04-14
PCRE Unicode Version => 14.0.0
PCRE JIT Support => enabled
PCRE JIT Target => x86 64bit (little endian + unaligned)

Directive => Local Value => Master Value
pcre.backtrack_limit => 1000000 => 1000000
pcre.jit => On => On
pcre.recursion_limit => 100000 => 100000

PDO

PDO support => enabled
PDO drivers => sqlite

pdo_sqlite

PDO Driver for SQLite 3.x => enabled
SQLite Library => 3.40.1

Phar

Phar: PHP Archive support => enabled
Phar API version => 1.1.1
Phar-based phar archives => enabled
Tar-based phar archives => enabled
ZIP-based phar archives => enabled
gzip compression => enabled
bzip2 compression => disabled (install ext/bz2)
Native OpenSSL support => enabled


Phar based on pear/PHP_Archive, original concept by Davey Shafik.
Phar fully realized by Gregory Beaver and Marcus Boerger.
Portions of tar implementation Copyright (c) 2003-2009 Tim Kientzle.
Directive => Local Value => Master Value
phar.cache_list => no value => no value
phar.readonly => On => On
phar.require_hash => On => On

posix

POSIX support => enabled

random

Version => 8.2.27

readline

Readline Support => enabled
Readline library => 8.2

Directive => Local Value => Master Value
cli.pager => no value => no value
cli.prompt => \b \>  => \b \> 

Reflection

Reflection => enabled

session

Session Support => enabled
Registered save handlers => files user 
Registered serializer handlers => php_serialize php php_binary 

Directive => Local Value => Master Value
session.auto_start => Off => Off
session.cache_expire => 180 => 180
session.cache_limiter => nocache => nocache
session.cookie_domain => no value => no value
session.cookie_httponly => Off => Off
session.cookie_lifetime => 0 => 0
session.cookie_path => / => /
session.cookie_samesite => no value => no value
session.cookie_secure => Off => Off
session.gc_divisor => 100 => 100
session.gc_maxlifetime => 1440 => 1440
session.gc_probability => 1 => 1
session.lazy_write => On => On
session.name => PHPSESSID => PHPSESSID
session.referer_check => no value => no value
session.save_handler => files => files
session.save_path => no value => no value
session.serialize_handler => php => php
session.sid_bits_per_character => 4 => 4
session.sid_length => 32 => 32
session.upload_progress.cleanup => On => On
session.upload_progress.enabled => On => On
session.upload_progress.freq => 1% => 1%
session.upload_progress.min_freq => 1 => 1
session.upload_progress.name => PHP_SESSION_UPLOAD_PROGRESS => PHP_SESSION_UPLOAD_PROGRESS
session.upload_progress.prefix => upload_progress_ => upload_progress_
session.use_cookies => On => On
session.use_only_cookies => On => On
session.use_strict_mode => Off => Off
session.use_trans_sid => Off => Off

SimpleXML

SimpleXML support => enabled
Schema support => enabled

sodium

sodium support => enabled
libsodium headers version => 1.0.18
libsodium library version => 1.0.18

SPL

SPL support => enabled
Interfaces => OuterIterator, RecursiveIterator, SeekableIterator, SplObserver, SplSubject
Classes => AppendIterator, ArrayIterator, ArrayObject, BadFunctionCallException, BadMethodCallException, CachingIterator, CallbackFilterIterator, DirectoryIterator, DomainException, EmptyIterator, FilesystemIterator, FilterIterator, GlobIterator, InfiniteIterator, InvalidArgumentException, IteratorIterator, LengthException, LimitIterator, LogicException, MultipleIterator, NoRewindIterator, OutOfBoundsException, OutOfRangeException, OverflowException, ParentIterator, RangeException, RecursiveArrayIterator, RecursiveCachingIterator, RecursiveCallbackFilterIterator, RecursiveDirectoryIterator, RecursiveFilterIterator, RecursiveIteratorIterator, RecursiveRegexIterator, RecursiveTreeIterator, RegexIterator, RuntimeException, SplDoublyLinkedList, SplFileInfo, SplFileObject, SplFixedArray, SplHeap, SplMinHeap, SplMaxHeap, SplObjectStorage, SplPriorityQueue, SplQueue, SplStack, SplTempFileObject, UnderflowException, UnexpectedValueException

sqlite3

SQLite3 support => enabled
SQLite Library => 3.40.1

Directive => Local Value => Master Value
sqlite3.defensive => On => On
sqlite3.extension_dir => no value => no value

standard

Dynamic Library Support => enabled
Path to sendmail => /usr/sbin/sendmail -t -i

Directive => Local Value => Master Value
assert.active => On => On
assert.bail => Off => Off
assert.callback => no value => no value
assert.exception => On => On
assert.warning => On => On
auto_detect_line_endings => Off => Off
default_socket_timeout => 60 => 60
from => no value => no value
session.trans_sid_hosts => no value => no value
session.trans_sid_tags => a=href,area=href,frame=src,form= => a=href,area=href,frame=src,form=
unserialize_max_depth => 4096 => 4096
url_rewriter.hosts => no value => no value
url_rewriter.tags => form= => form=
user_agent => no value => no value

tokenizer

Tokenizer Support => enabled

xml

XML Support => active
XML Namespace Support => active
libxml2 Version => 2.9.14

xmlreader

XMLReader => enabled

xmlwriter

XMLWriter => enabled

zlib

ZLib Support => enabled
Stream Wrapper => compress.zlib://
Stream Filter => zlib.inflate, zlib.deflate
Compiled Version => 1.2.13
Linked Version => 1.2.13

Directive => Local Value => Master Value
zlib.output_compression => Off => Off
zlib.output_compression_level => -1 => -1
zlib.output_handler => no value => no value

Additional Modules

Module Name

Environment

Variable => Value
SSH_CLIENT => deleted
PHP_INI_DIR => /usr/local/etc/php
SHLVL => 1
TEST_PHP_SRCDIR => /tmp/php-v8js
HOME => /root
SSH_TTY => deleted
PHP_LDFLAGS => -Wl,-O1 -pie
TEST_PHP_CGI_EXECUTABLE => /usr/local/bin/php-cgi
MAKEFLAGS =>  
PHP_CFLAGS => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
PHP_VERSION => 8.2.27
GPG_KEYS => 39B641343D8C104B2B146DC3F9C39DC0B9698544 E60913E4DF209907D8E30D96659A97C9CF2A795A 1198C0117593497A5EC5C199286AF1F9897469DC
PHP_ASC_URL => https://www.php.net/distributions/php-8.2.27.tar.xz.asc
PHP_CPPFLAGS => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
TEST_PHP_EXECUTABLE => /usr/local/bin/php
_ => /usr/local/bin/php
PHP_URL => https://www.php.net/distributions/php-8.2.27.tar.xz
PATH => /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
MAKELEVEL => 1
PREFIX => php8.2.27_x86_64__
SSH_AUTH_SOCK => deleted
TEST_PHPDBG_EXECUTABLE => /usr/local/bin/phpdbg
PWD => /tmp/php-v8js
PHPIZE_DEPS => autoconf 		dpkg-dev 		file 		g++ 		gcc 		libc-dev 		make 		pkg-config 		re2c
PHP_SHA256 => 3eec91294d8c09b3df80b39ec36d574ed9b05de4c8afcb25fa215d48f9ecbc6b
SSH_CONNECTION => deleted
CC => cc
MFLAGS =>  

PHP Variables

Variable => Value
$_SERVER['SSH_CLIENT'] => deleted
$_SERVER['PHP_INI_DIR'] => /usr/local/etc/php
$_SERVER['SHLVL'] => 1
$_SERVER['TEST_PHP_SRCDIR'] => /tmp/php-v8js
$_SERVER['HOME'] => /root
$_SERVER['SSH_TTY'] => deleted
$_SERVER['PHP_LDFLAGS'] => -Wl,-O1 -pie
$_SERVER['TEST_PHP_CGI_EXECUTABLE'] => /usr/local/bin/php-cgi
$_SERVER['MAKEFLAGS'] => 
$_SERVER['PHP_CFLAGS'] => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
$_SERVER['PHP_VERSION'] => 8.2.27
$_SERVER['GPG_KEYS'] => 39B641343D8C104B2B146DC3F9C39DC0B9698544 E60913E4DF209907D8E30D96659A97C9CF2A795A 1198C0117593497A5EC5C199286AF1F9897469DC
$_SERVER['PHP_ASC_URL'] => https://www.php.net/distributions/php-8.2.27.tar.xz.asc
$_SERVER['PHP_CPPFLAGS'] => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
$_SERVER['TEST_PHP_EXECUTABLE'] => /usr/local/bin/php
$_SERVER['_'] => /usr/local/bin/php
$_SERVER['PHP_URL'] => https://www.php.net/distributions/php-8.2.27.tar.xz
$_SERVER['PATH'] => /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
$_SERVER['MAKELEVEL'] => 1
$_SERVER['PREFIX'] => php8.2.27_x86_64__
$_SERVER['SSH_AUTH_SOCK'] => deleted
$_SERVER['TEST_PHPDBG_EXECUTABLE'] => /usr/local/bin/phpdbg
$_SERVER['PWD'] => /tmp/php-v8js
$_SERVER['PHPIZE_DEPS'] => autoconf 		dpkg-dev 		file 		g++ 		gcc 		libc-dev 		make 		pkg-config 		re2c
$_SERVER['PHP_SHA256'] => 3eec91294d8c09b3df80b39ec36d574ed9b05de4c8afcb25fa215d48f9ecbc6b
$_SERVER['SSH_CONNECTION'] => deleted
$_SERVER['CC'] => cc
$_SERVER['MFLAGS'] => 
$_SERVER['PHP_SELF'] => 
$_SERVER['SCRIPT_NAME'] => 
$_SERVER['SCRIPT_FILENAME'] => 
$_SERVER['PATH_TRANSLATED'] => 
$_SERVER['DOCUMENT_ROOT'] => 
$_SERVER['REQUEST_TIME_FLOAT'] => 1736413968.4729
$_SERVER['REQUEST_TIME'] => 1736413968
$_SERVER['argv'] => Array
(
)

$_SERVER['argc'] => 0
$_ENV['SSH_CLIENT'] => deleted
$_ENV['PHP_INI_DIR'] => /usr/local/etc/php
$_ENV['SHLVL'] => 1
$_ENV['TEST_PHP_SRCDIR'] => /tmp/php-v8js
$_ENV['HOME'] => /root
$_ENV['SSH_TTY'] => deleted
$_ENV['PHP_LDFLAGS'] => -Wl,-O1 -pie
$_ENV['TEST_PHP_CGI_EXECUTABLE'] => /usr/local/bin/php-cgi
$_ENV['MAKEFLAGS'] => 
$_ENV['PHP_CFLAGS'] => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
$_ENV['PHP_VERSION'] => 8.2.27
$_ENV['GPG_KEYS'] => 39B641343D8C104B2B146DC3F9C39DC0B9698544 E60913E4DF209907D8E30D96659A97C9CF2A795A 1198C0117593497A5EC5C199286AF1F9897469DC
$_ENV['PHP_ASC_URL'] => https://www.php.net/distributions/php-8.2.27.tar.xz.asc
$_ENV['PHP_CPPFLAGS'] => -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
$_ENV['TEST_PHP_EXECUTABLE'] => /usr/local/bin/php
$_ENV['_'] => /usr/local/bin/php
$_ENV['PHP_URL'] => https://www.php.net/distributions/php-8.2.27.tar.xz
$_ENV['PATH'] => /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
$_ENV['MAKELEVEL'] => 1
$_ENV['PREFIX'] => php8.2.27_x86_64__
$_ENV['SSH_AUTH_SOCK'] => deleted
$_ENV['TEST_PHPDBG_EXECUTABLE'] => /usr/local/bin/phpdbg
$_ENV['PWD'] => /tmp/php-v8js
$_ENV['PHPIZE_DEPS'] => autoconf 		dpkg-dev 		file 		g++ 		gcc 		libc-dev 		make 		pkg-config 		re2c
$_ENV['PHP_SHA256'] => 3eec91294d8c09b3df80b39ec36d574ed9b05de4c8afcb25fa215d48f9ecbc6b
$_ENV['SSH_CONNECTION'] => deleted
$_ENV['CC'] => cc
$_ENV['MFLAGS'] => 
```

</details>

## PHP 8.1

**TLDR: 179/180 (+2 skip) tests passed (99.4%)** 

<details>
<summary>php 8.1.31 (on x86_64) test report:</summary>

```
=====================================================================
TIME END 2025-01-09 09:12:46

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   33
---------------------------------------------------------------------

Number of tests :  182               180
Tests skipped   :    2 (  1.1%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    1 (  0.5%) (  0.6%)
Tests passed    :  179 ( 98.4%) ( 99.4%)
---------------------------------------------------------------------
Time taken      :    9 seconds
=====================================================================

=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Test V8::executeString() : Time limit [tests/time_limit.phpt]
=====================================================================
```