### PR TITLE
Fixing memory leaks and deprecations

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -124,6 +124,9 @@ jobs:
                     PHP_DEV=$(apk search -q 'php[0-9]*-dev' | grep -E '^php[0-9]+-dev$' | sort -V | tail -1)
                     echo "Installing $PHP_DEV"
                     apk add $PHP_DEV nodejs-dev g++ make
+                    PHP_VER=$(echo $PHP_DEV | grep -oE '[0-9]+')                                                                        
+                    [ ! -e /usr/bin/phpize ] && ln -s /usr/bin/phpize$PHP_VER /usr/bin/phpize                                                               
+                    [ ! -e /usr/bin/php-config ] && ln -s /usr/bin/php-config$PHP_VER /usr/bin/php-config
                 shell: alpine.sh --root {0}
 
             -   name: Build extension

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,7 +37,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -112,7 +112,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
 
             -   name: Setup latest Alpine Linux
                 uses: jirutka/setup-alpine@v1
@@ -120,7 +120,10 @@ jobs:
             -   name: Install dependencies
                 run: |
                     cat /etc/alpine-release
-                    apk add php83-dev nodejs-dev g++ make
+                    apk update
+                    PHP_DEV=$(apk search -q 'php[0-9]*-dev' | grep -E '^php[0-9]+-dev$' | sort -V | tail -1)
+                    echo "Installing $PHP_DEV"
+                    apk add $PHP_DEV nodejs-dev g++ make
                 shell: alpine.sh --root {0}
 
             -   name: Build extension

--- a/v8js_array_access.cc
+++ b/v8js_array_access.cc
@@ -59,7 +59,7 @@ static zval v8js_array_access_dispatch(zend_object *object, const char *method_n
 V8JS_INTERCEPTED v8js_array_access_getter(uint32_t index, const v8::PropertyCallbackInfo<v8::Value>& info) /* {{{ */
 {
 	v8::Isolate *isolate = info.GetIsolate();
-	v8::Local<v8::Object> self = info.Holder();
+	v8::Local<v8::Object> self = info.This();
 
 	zend_object *object = reinterpret_cast<zend_object *>(self->GetAlignedPointerFromInternalField(1));
 
@@ -83,7 +83,7 @@ V8JS_INTERCEPTED v8js_array_access_setter(uint32_t index, v8::Local<v8::Value> v
 								  const V8JS_SETTER_PROPERTY_CALLBACK_INFO &info) /* {{{ */
 {
 	v8::Isolate *isolate = info.GetIsolate();
-	v8::Local<v8::Object> self = info.Holder();
+	v8::Local<v8::Object> self = info.This();
 
 	zend_object *object = reinterpret_cast<zend_object *>(self->GetAlignedPointerFromInternalField(1));
 
@@ -157,7 +157,7 @@ static bool v8js_array_access_isset_p(zend_object *object, int index) /* {{{ */
 static void v8js_array_access_length(v8::Local<v8::String> property, const v8::PropertyCallbackInfo<v8::Value>& info) /* {{{ */
 {
 	v8::Isolate *isolate = info.GetIsolate();
-	v8::Local<v8::Object> self = info.Holder();
+	v8::Local<v8::Object> self = info.This();
 
 	zend_object *object = reinterpret_cast<zend_object *>(self->GetAlignedPointerFromInternalField(1));
 
@@ -169,7 +169,7 @@ static void v8js_array_access_length(v8::Local<v8::String> property, const v8::P
 V8JS_INTERCEPTED v8js_array_access_deleter(uint32_t index, const v8::PropertyCallbackInfo<v8::Boolean>& info) /* {{{ */
 {
 	v8::Isolate *isolate = info.GetIsolate();
-	v8::Local<v8::Object> self = info.Holder();
+	v8::Local<v8::Object> self = info.This();
 
 	zend_object *object = reinterpret_cast<zend_object *>(self->GetAlignedPointerFromInternalField(1));
 
@@ -187,7 +187,7 @@ V8JS_INTERCEPTED v8js_array_access_deleter(uint32_t index, const v8::PropertyCal
 V8JS_INTERCEPTED v8js_array_access_query(uint32_t index, const v8::PropertyCallbackInfo<v8::Integer>& info) /* {{{ */
 {
 	v8::Isolate *isolate = info.GetIsolate();
-	v8::Local<v8::Object> self = info.Holder();
+	v8::Local<v8::Object> self = info.This();
 
 	zend_object *object = reinterpret_cast<zend_object *>(self->GetAlignedPointerFromInternalField(1));
 
@@ -206,7 +206,7 @@ V8JS_INTERCEPTED v8js_array_access_query(uint32_t index, const v8::PropertyCallb
 void v8js_array_access_enumerator(const v8::PropertyCallbackInfo<v8::Array>& info) /* {{{ */
 {
 	v8::Isolate *isolate = info.GetIsolate();
-	v8::Local<v8::Object> self = info.Holder();
+	v8::Local<v8::Object> self = info.This();
 
 	zend_object *object = reinterpret_cast<zend_object *>(self->GetAlignedPointerFromInternalField(1));
 
@@ -240,7 +240,7 @@ V8JS_INTERCEPTED v8js_array_access_named_getter(v8::Local<v8::Name> property_nam
 		return V8JS_INTERCEPTED_YES;
 	}
 
-	v8::Local<v8::Value> ret_value = v8js_named_property_callback(info.GetIsolate(), info.Holder(), property, V8JS_PROP_GETTER);
+	v8::Local<v8::Value> ret_value = v8js_named_property_callback(info.GetIsolate(), info.This(), property, V8JS_PROP_GETTER);
 
 	if(ret_value.IsEmpty()) {
 		v8::Local<v8::Array> arr = v8::Array::New(isolate);

--- a/v8js_class.cc
+++ b/v8js_class.cc
@@ -73,11 +73,43 @@ public:
 #endif  /** USE_INTERNAL_ALLOCATOR */
 
 
+static HashTable *v8js_get_gc(zend_object *object, zval **table, int *n) /* {{{ */
+{
+	v8js_ctx *c = v8js_ctx_fetch_object(object);
+
+	int count = 3 + (int)c->weak_objects.size();
+
+	if (c->gc_buffer_size < count) {
+		if (c->gc_buffer) efree(c->gc_buffer);
+		c->gc_buffer = (zval *)safe_emalloc(count, sizeof(zval), 0);
+		c->gc_buffer_size = count;
+	}
+
+	int i = 0;
+	ZVAL_COPY_VALUE(&c->gc_buffer[i++], &c->module_normaliser);
+	ZVAL_COPY_VALUE(&c->gc_buffer[i++], &c->module_loader);
+	ZVAL_COPY_VALUE(&c->gc_buffer[i++], &c->exception_filter);
+
+	for (auto &pair : c->weak_objects) {
+		ZVAL_OBJ(&c->gc_buffer[i++], pair.first);
+	}
+
+	*table = c->gc_buffer;
+	*n = i;
+	return NULL;
+}
+/* }}} */
+
+
 static void v8js_free_storage(zend_object *object) /* {{{ */
 {
 	v8js_ctx *c = v8js_ctx_fetch_object(object);
 
 	zend_object_std_dtor(&c->std);
+
+	if (c->gc_buffer) {
+		efree(c->gc_buffer);
+	}
 
 	zval_ptr_dtor(&c->module_normaliser);
 	zval_ptr_dtor(&c->module_loader);
@@ -315,6 +347,9 @@ static PHP_METHOD(V8Js, __construct)
 	ZVAL_NULL(&c->module_normaliser);
 	ZVAL_NULL(&c->module_loader);
 	ZVAL_NULL(&c->exception_filter);
+
+	c->gc_buffer = NULL;
+	c->gc_buffer_size = 0;
 
 	// Isolate execution
 	v8::Isolate *isolate = c->isolate;
@@ -688,7 +723,9 @@ static PHP_METHOD(V8Js, setModuleNormaliser)
 	}
 
 	c = Z_V8JS_CTX_OBJ_P(getThis());
+	zval tmp = c->module_normaliser;
 	ZVAL_COPY(&c->module_normaliser, callable);
+	zval_ptr_dtor(&tmp);
 }
 /* }}} */
 
@@ -704,7 +741,9 @@ static PHP_METHOD(V8Js, setModuleLoader)
 	}
 
 	c = Z_V8JS_CTX_OBJ_P(getThis());
+	zval tmp = c->module_loader;
 	ZVAL_COPY(&c->module_loader, callable);
+	zval_ptr_dtor(&tmp);
 }
 /* }}} */
 
@@ -719,7 +758,9 @@ static PHP_METHOD(V8Js, setExceptionFilter)
 	}
 
 	v8js_ctx *c = Z_V8JS_CTX_OBJ_P(getThis());
+	zval tmp = c->exception_filter;
 	ZVAL_COPY(&c->exception_filter, callable);
+	zval_ptr_dtor(&tmp);
 }
 /* }}} */
 
@@ -815,7 +856,7 @@ static PHP_METHOD(V8Js, setAverageObjectSize)
 static void v8js_persistent_zval_ctor(zval *p) /* {{{ */
 {
 	assert(Z_TYPE_P(p) == IS_STRING);
-	Z_STR_P(p) = zend_string_dup(Z_STR_P(p), 1);
+	Z_STR_P(p) = zend_string_init(ZSTR_VAL(Z_STR_P(p)), ZSTR_LEN(Z_STR_P(p)), 1);
 }
 /* }}} */
 
@@ -1077,6 +1118,7 @@ PHP_MINIT_FUNCTION(v8js_class) /* {{{ */
 	v8js_object_handlers.clone_obj = NULL;
 	v8js_object_handlers.write_property = v8js_write_property;
 	v8js_object_handlers.unset_property = v8js_unset_property;
+	v8js_object_handlers.get_gc = v8js_get_gc;
 
 	/* V8Js Class Constants */
 	zend_declare_class_constant_string(php_ce_v8js, ZEND_STRL("V8_VERSION"),		PHP_V8_VERSION);

--- a/v8js_class.h
+++ b/v8js_class.h
@@ -74,6 +74,9 @@ struct v8js_ctx {
   zval zval_snapshot_blob;
   v8::StartupData snapshot_blob;
 
+  zval *gc_buffer;
+  int gc_buffer_size;
+
   zend_object std;
 };
 /* }}} */

--- a/v8js_exceptions.cc
+++ b/v8js_exceptions.cc
@@ -97,7 +97,7 @@ void v8js_create_script_exception(zval *return_value, v8::Isolate *isolate, v8::
 		if(try_catch->Exception()->IsObject() && try_catch->Exception()->ToObject(context).ToLocal(&error_object) && error_object->InternalFieldCount() == 2) {
 			zend_object *php_exception = reinterpret_cast<zend_object *>(error_object->GetAlignedPointerFromInternalField(1));
 
-			zend_class_entry *exception_ce = zend_exception_get_default();
+			zend_class_entry *exception_ce = zend_ce_exception;
 			if (instanceof_function(php_exception->ce, exception_ce)) {
 #ifdef GC_ADDREF
 				GC_ADDREF(php_exception);

--- a/v8js_object_export.cc
+++ b/v8js_object_export.cc
@@ -50,6 +50,7 @@ v8::Local<v8::Value> v8js_propagate_exception(v8js_ctx *ctx) /* {{{ */
 	}
 
 	zval tmp_zv;
+	ZVAL_UNDEF(&tmp_zv);
 
 	if (Z_TYPE(ctx->exception_filter) != IS_NULL) {
 		zval params[1];
@@ -65,6 +66,7 @@ v8::Local<v8::Value> v8js_propagate_exception(v8js_ctx *ctx) /* {{{ */
 		} else {
 			return_value = ctx->isolate->ThrowException(zval_to_v8js(&tmp_zv, ctx->isolate));
 		}
+		zval_ptr_dtor(&tmp_zv);
 	} else {
 		ZVAL_OBJ(&tmp_zv, EG(exception));
 		return_value = ctx->isolate->ThrowException(zval_to_v8js(&tmp_zv, ctx->isolate));
@@ -212,7 +214,7 @@ failure:
 		return_value = v8js_propagate_exception(ctx);
 	} else if (Z_TYPE(retval) == IS_OBJECT && Z_OBJ(retval) == object) {
 		// special case: "return $this"
-		return_value = info.Holder();
+		return_value = info.This();
 	} else {
 		return_value = zval_to_v8js(&retval, isolate);
 	}
@@ -227,7 +229,7 @@ failure:
 /* Callback for PHP methods and functions */
 void v8js_php_callback(const v8::FunctionCallbackInfo<v8::Value>& info) /* {{{ */
 {
-	v8::Local<v8::Object> self = info.Holder();
+	v8::Local<v8::Object> self = info.This();
 
 	zend_object *object = reinterpret_cast<zend_object *>(self->GetAlignedPointerFromInternalField(1));
 	zend_function *method_ptr;
@@ -364,7 +366,7 @@ static void v8js_named_property_enumerator(const v8::PropertyCallbackInfo<v8::Ar
 	v8::Isolate *isolate = info.GetIsolate();
 	v8::Local<v8::Context> v8_context = isolate->GetEnteredOrMicrotaskContext();
 
-	v8::Local<v8::Object> self = info.Holder();
+	v8::Local<v8::Object> self = info.This();
 	v8::Local<v8::Array> result = v8::Array::New(isolate, 0);
 	uint32_t result_len = 0;
 
@@ -466,7 +468,7 @@ static void v8js_invoke_callback(const v8::FunctionCallbackInfo<v8::Value>& info
 	v8::Isolate *isolate = info.GetIsolate();
 	v8::Local<v8::Context> v8_context = isolate->GetEnteredOrMicrotaskContext();
 
-	v8::Local<v8::Object> self = info.Holder();
+	v8::Local<v8::Object> self = info.This();
 	v8::Local<v8::Function> cb = v8::Local<v8::Function>::Cast(info.Data());
 	int argc = info.Length(), i;
 	v8::Local<v8::Value> *argv = static_cast<v8::Local<v8::Value> *>(alloca(sizeof(v8::Local<v8::Value>) * argc));
@@ -511,7 +513,7 @@ static void v8js_fake_call_impl(const v8::FunctionCallbackInfo<v8::Value>& info)
 	v8::Isolate *isolate = info.GetIsolate();
 	v8::Local<v8::Context> v8_context = isolate->GetEnteredOrMicrotaskContext();
 
-	v8::Local<v8::Object> self = info.Holder();
+	v8::Local<v8::Object> self = info.This();
 	v8::Local<v8::Value> return_value = V8JS_NULL;
 
 	char *error;
@@ -859,7 +861,7 @@ v8::Local<v8::Value> v8js_named_property_callback(v8::Isolate *isolate, v8::Loca
 
 static V8JS_INTERCEPTED v8js_named_property_getter(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Value> &info) /* {{{ */
 {
-	v8::Local<v8::Value> r = v8js_named_property_callback(info.GetIsolate(), info.Holder(), property, V8JS_PROP_GETTER);
+	v8::Local<v8::Value> r = v8js_named_property_callback(info.GetIsolate(), info.This(), property, V8JS_PROP_GETTER);
 
 	if (r.IsEmpty()) {
 		return V8JS_INTERCEPTED_NO;
@@ -872,7 +874,7 @@ static V8JS_INTERCEPTED v8js_named_property_getter(v8::Local<v8::Name> property,
 
 static V8JS_INTERCEPTED v8js_named_property_setter(v8::Local<v8::Name> property, v8::Local<v8::Value> value, const V8JS_SETTER_PROPERTY_CALLBACK_INFO &info) /* {{{ */
 {
-	v8::Local<v8::Value> r = v8js_named_property_callback(info.GetIsolate(), info.Holder(), property, V8JS_PROP_SETTER, value);
+	v8::Local<v8::Value> r = v8js_named_property_callback(info.GetIsolate(), info.This(), property, V8JS_PROP_SETTER, value);
 #if PHP_V8_HAS_INTERCEPTED
 	return r.IsEmpty() ? v8::Intercepted::kNo : v8::Intercepted::kYes;
 #else
@@ -883,7 +885,7 @@ static V8JS_INTERCEPTED v8js_named_property_setter(v8::Local<v8::Name> property,
 
 static V8JS_INTERCEPTED v8js_named_property_query(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Integer> &info) /* {{{ */
 {
-	v8::Local<v8::Value> r = v8js_named_property_callback(info.GetIsolate(), info.Holder(), property, V8JS_PROP_QUERY);
+	v8::Local<v8::Value> r = v8js_named_property_callback(info.GetIsolate(), info.This(), property, V8JS_PROP_QUERY);
 	if (r.IsEmpty()) {
 		return V8JS_INTERCEPTED_NO;
 	}
@@ -901,7 +903,7 @@ static V8JS_INTERCEPTED v8js_named_property_query(v8::Local<v8::Name> property, 
 
 static V8JS_INTERCEPTED v8js_named_property_deleter(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Boolean> &info) /* {{{ */
 {
-	v8::Local<v8::Value> r = v8js_named_property_callback(info.GetIsolate(), info.Holder(), property, V8JS_PROP_DELETER);
+	v8::Local<v8::Value> r = v8js_named_property_callback(info.GetIsolate(), info.This(), property, V8JS_PROP_DELETER);
 	if (r.IsEmpty()) {
 		return V8JS_INTERCEPTED_NO;
 	}

--- a/v8js_variables.cc
+++ b/v8js_variables.cc
@@ -76,7 +76,7 @@ void v8js_register_accessors(std::vector<v8js_accessor_ctx*> *accessor_list, v8:
 
         // Create context to store accessor data
         v8js_accessor_ctx *ctx = (v8js_accessor_ctx *)emalloc(sizeof(v8js_accessor_ctx));
-        ctx->variable_name = zend_string_copy(Z_STR_P(item));
+        ctx->variable_name = zend_string_init(ZSTR_VAL(Z_STR_P(item)), ZSTR_LEN(Z_STR_P(item)), 1);
         ctx->isolate = isolate;
 
 		/* Set the variable fetch callback for given symbol on named property */


### PR DESCRIPTION
This one has fixes for a few outstanding items, generally relating to memory leaks or deprecations/compatibility.

- PHP8.5 removes `zend_exception_get_default()`. Code updated to use `zend_ce_exception()`, available since PHP7.0. Fixes #544 
- Resolved memory leak on repeated setExceptionFilter / setModuleLoader / setModuleNormaliser calls. First bit needed to fix #543
- Resolved a memory leak with closures/circular refs. This one fixes #480 and  #543 
- Fixed persistent string crash on FPM/Apache graceful restart. Fixes #432 
- Also fixed a V8 deprecation - migrated `Holder()` → `This()`. No specific issue open afaik, but this one was stopping us building.

All tests pass (as do our own, and we have a fair few, albeit coving specific weird edge cases and things specific to the way we do things). Hopefully this is ok, @stesie  ? Hoping to look at a few more too and (finally) perhaps look at the 3.0.0 thing. We've been building against V8 AND libnode, both working well, so perhaps I can get some of the docs polished in the next batch.